### PR TITLE
Spotify Track ID issue

### DIFF
--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -33,9 +33,11 @@ class RankingController extends Controller
 
     public function create(CreateRankingRequest $request): JsonResponse
     {
+        $ranking = Ranking::start($request);
+
         return response()->json([
             'redirect' => route('rank.show', [
-                'id' => Ranking::start($request)->id,
+                'id' => $ranking->getKey()
             ]),
         ], 200);
     }
@@ -75,12 +77,8 @@ class RankingController extends Controller
         return response()->json([
             'message' => 'Your ranking has been deleted.',
             'rankings' => Ranking::query()
-                ->where('user_id', auth()->id())
-                ->with('user', 'artist')
-                ->with('songs', fn ($q) => $q->where('rank', 1))
-                ->withCount('songs')
-                ->latest()
-                ->paginate(5),
+                ->forProfilePage(auth()->user())
+                ->get()
         ], 200);
     }
 }

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -7,6 +7,7 @@ class Song extends Model
     protected $fillable = [
         'ranking_id',
         'spotify_song_id',
+        'uuid',
         'title',
         'rank',
         'cover',
@@ -16,6 +17,6 @@ class Song extends Model
     {
         parent::boot();
 
-        static::addGlobalScope('default_order', fn ($query) => $query->orderBy('rank', 'ASC'));
+        static::addGlobalScope('default_order', fn ($query) => $query->orderBy('rank', 'asc'));
     }
 }

--- a/database/factories/SongFactory.php
+++ b/database/factories/SongFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Models\Ranking;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 
 class SongFactory extends Factory
 {
@@ -15,6 +16,7 @@ class SongFactory extends Factory
             'title' => fake()->sentence(rand(1, 5)),
             'rank' => 0,
             'cover' => fake()->imageUrl(200, 200, 'song', true),
+            'uuid' => Str::uuid(),
         ];
     }
 }

--- a/database/migrations/2025_05_09_200053_add_uuid_to_songs_table.php
+++ b/database/migrations/2025_05_09_200053_add_uuid_to_songs_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\Song;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('songs', function (Blueprint $table) {
+            $table->uuid('uuid')->nullable()->after('spotify_song_id');
+        });
+
+        DB::transaction(function () {            
+            Song::query()->withTrashed()->chunk(1000, function ($songs) {
+                $songs->each(fn (Song $song) => $song->update(['uuid' => Str::uuid()]));
+            });
+        });
+
+        Schema::table('songs', function (Blueprint $table) {
+            $table->uuid('uuid')->nullable(false)->change();
+        });
+
+        Schema::table('songs', function (Blueprint $table) {
+            $table->dropUnique('songs_ranking_id_spotify_song_id_unique');
+            $table->unique(['ranking_id', 'uuid']);
+        });
+    }
+};

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -11,6 +11,6 @@
             <spotifysearch :artistplaceholder='"{{ $randomArtist }}"'></spotifysearch>
         </div>
 
-        <survey />
+        {{-- <survey /> --}}
     </div>
 @endsection


### PR DESCRIPTION
- in very rare instances, Spotify uses the same unique id for a track again if the track is a re-recording of a song the artist already released. This happened with a user who was ranking the artist Queen. The tracks: My Fairy King - BBC Session / February 5th 1973, Langham 1 Studio & My Fairy King - BBC Session 1 / 1973 triggered it. It's worth noting that normal rereleases like remasters or taylors version don't cause this.

- fixed delete ranking issue. It always deleted, but didn't refresh correctly.