### PR TITLE
feat: Introduce Leaderboards and enhance ranking exploration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ yarn-error.log
 .DS_Store
 .mcp.json
 boost.json
+_ide_helper.php
+_ide_helper_models.php
+.phpstorm.meta.php
 /public/js/filament
 /public/css/filament
 /public/build/filament

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,18 @@ songrank.dev — a Laravel 12 application that ranks songs via a merge-sort algo
 - Tests use SQLite in-memory database (configured in `phpunit.xml`)
 - Only Feature tests are active; Unit test suite is commented out
 
+#### Test File Structure
+Every Pest test file follows this order, top to bottom:
+1. **Imports** — model/class `use` statements, then `use function Pest\Laravel\...` function imports
+2. **`beforeEach()`** — shared arrangement (only when needed)
+3. **`describe()` blocks** — every test lives inside a describe group
+4. **Helper functions** — file-specific helpers at the bottom
+
+Additional conventions:
+- Use `Pest\Laravel` functions (`get()`, `actingAs()`, `assertGuest()`, ...) instead of `$this->get()` etc. — Intelephense cannot resolve `$this` inside Pest closures
+- Avoid `$this->property` state in `beforeEach()` for the same reason; prefer helper functions
+- Cross-file helpers (e.g. `publicCompletedRanking()`) live in `tests/Pest.php`; helper function names are global, so they must be unique across the suite
+
 ### Code Formatting
 - `./vendor/bin/pint` — Run Laravel Pint (PHP code formatter, PSR-12 + Laravel conventions)
 
@@ -249,6 +261,9 @@ protected function isAccessible(User $user, ?string $path = null): bool
 - Use `php artisan make:` commands to create new files (i.e. migrations, controllers, models, etc.). You can list available Artisan commands using the `list-artisan-commands` tool.
 - If you're creating a generic PHP class, use `php artisan make:class`.
 - Pass `--no-interaction` to all Artisan commands to ensure they work without user input. You should also pass the correct `--options` to ensure correct behavior.
+- Use the Laravel Str facade functions over PHP string functions
+- When it makes sense, use Laravel Collection over traditional arrays
+- Use Collections and collection chains over foreach loops for data processing.
 
 ## Database
 
@@ -256,7 +271,7 @@ protected function isAccessible(User $user, ?string $path = null): bool
 - Use Eloquent models and relationships before suggesting raw database queries.
 - Avoid `DB::`; prefer `Model::query()`. Generate code that leverages Laravel's ORM capabilities rather than bypassing them.
 - Generate code that prevents N+1 query problems by using eager loading.
-- Use Laravel's query builder for very complex database operations.
+- Use Laravel's query builder for very complex database operations. Explain why you did so.
 
 ### Model Creation
 

--- a/app/Actions/CompleteSongRankProcess.php
+++ b/app/Actions/CompleteSongRankProcess.php
@@ -44,5 +44,7 @@ final class CompleteSongRankProcess
 
             RankingCompletedStat::increase();
         });
+
+        cache()->forget('explore:total-rankings');
     }
 }

--- a/app/Actions/Rankings/DestroyRanking.php
+++ b/app/Actions/Rankings/DestroyRanking.php
@@ -5,7 +5,6 @@ namespace App\Actions\Rankings;
 use App\Models\Ranking;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
 
 final class DestroyRanking
 {
@@ -15,5 +14,7 @@ final class DestroyRanking
             $ranking->songs()->delete();
             $ranking->delete();
         });
+
+        cache()->forget('explore:total-rankings');
     }
 }

--- a/app/Actions/Rankings/StorePlaylistRanking.php
+++ b/app/Actions/Rankings/StorePlaylistRanking.php
@@ -36,7 +36,7 @@ final class StorePlaylistRanking
                 'name' => Str::limit($name, 30),
                 'is_public' => $attributes['is_public'] ?? false,
                 'comments_enabled' => $attributes['comments_enabled'] ?? false,
-                'comments_replies_enabled' => $attributes['comments_enabled'] ?? false,
+                'comments_replies_enabled' => $attributes['comments_replies_enabled'] ?? false,
             ]);
 
             $ranking->sortingState()->create();

--- a/app/Console/Commands/UpdateArtistImages.php
+++ b/app/Console/Commands/UpdateArtistImages.php
@@ -30,7 +30,7 @@ class UpdateArtistImages extends Command
         Artist::query()->chunk(50, function ($chunk) {
             $ids = $chunk->pluck('artist_id')->implode(',');
 
-            $response = Http::withToken(auth()->user()->external_token)
+            $response = Http::withToken(Auth::user()->external_token)
                 ->get("https://api.spotify.com/v1/artists?ids={$ids}");
 
             $upserts = collect($response->json('artists'))

--- a/app/Filament/Resources/Comments/Tables/CommentsTable.php
+++ b/app/Filament/Resources/Comments/Tables/CommentsTable.php
@@ -9,6 +9,7 @@ use Filament\Actions\ViewAction;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Support\Facades\Auth;
 
 class CommentsTable
 {
@@ -28,13 +29,13 @@ class CommentsTable
                     ->label('Created At')
                     ->dateTime(
                         format: 'M j, Y g:i A T',
-                        timezone: auth()->user()->timezone
+                        timezone: Auth::user()->timezone
                     ),
                 TextColumn::make('updated_at')
                     ->label('Updated At')
                     ->dateTime(
                         format: 'M j, Y g:i A T',
-                        timezone: auth()->user()->timezone
+                        timezone: Auth::user()->timezone
                     ),
             ])
             ->filters([

--- a/app/Filament/Widgets/Concerns/HasDateFilters.php
+++ b/app/Filament/Widgets/Concerns/HasDateFilters.php
@@ -9,6 +9,7 @@ use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Select;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Utilities\Set;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
 
 trait HasDateFilters
@@ -152,7 +153,7 @@ trait HasDateFilters
 
     private function userTimezone(): string
     {
-        return auth()->user()->timezone;
+        return Auth::user()->timezone;
     }
 
     private function dateRangeLabels(Carbon $start, Carbon $end, string $format, string $interval = '1 day'): array

--- a/app/Filament/Widgets/LoginsWidget.php
+++ b/app/Filament/Widgets/LoginsWidget.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Carbon\Carbon;
 use Filament\Widgets\StatsOverviewWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Facades\Auth;
 use Kyledoesdev\Essentials\Stats\LoginStat;
 
 class LoginsWidget extends StatsOverviewWidget
@@ -16,7 +17,7 @@ class LoginsWidget extends StatsOverviewWidget
 
     protected function getStats(): array
     {
-        $timezone = auth()->user()->timezone;
+        $timezone = Auth::user()->timezone;
         $now = now()->tz($timezone);
 
         $totalUsers = User::query()->count();

--- a/app/Livewire/Dashboard/InProcessRankings.php
+++ b/app/Livewire/Dashboard/InProcessRankings.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Dashboard;
 
 use App\Models\Ranking;
+use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 
 class InProcessRankings extends Component
@@ -11,7 +12,7 @@ class InProcessRankings extends Component
     {
         return view('livewire.dashboard.in-process-rankings', [
             'rankings' => Ranking::query()
-                ->where('user_id', auth()->id())
+                ->where('user_id', Auth::id())
                 ->where('is_ranked', false)
                 ->with(['artist', 'user'])
                 ->with('songs', fn ($q) => $q->where('rank', 1))

--- a/app/Livewire/Explorer.php
+++ b/app/Livewire/Explorer.php
@@ -2,7 +2,6 @@
 
 namespace App\Livewire;
 
-use App\Models\Artist;
 use App\Models\Ranking;
 use Livewire\Attributes\Computed;
 use Livewire\Component;
@@ -11,20 +10,12 @@ class Explorer extends Component
 {
     public ?string $search = null;
 
-    public ?string $artist = null;
-
-    public ?string $playlist = null;
-
-    public bool $isSideBarOpen = false;
-
-    public bool $isPlaylistSideBarOpen = false;
-
-    public int $perPage = 6;
+    public int $perPage = 12;
 
     public function render()
     {
         return view('livewire.explorer', [
-            'artists' => cache()->remember('explore:top-artists', now()->addHour(), fn () => Artist::query()->topArtists()->get()),
+            'totalRankings' => cache()->remember('explore:total-rankings', now()->addDay(), fn () => Ranking::query()->explorableCount()),
         ]);
     }
 
@@ -32,11 +23,7 @@ class Explorer extends Component
     public function rankings()
     {
         return Ranking::query()
-            ->forExplorePage([
-                'search' => $this->search,
-                'artist' => $this->artist,
-                'playlist' => $this->playlist,
-            ])
+            ->forExplorePage($this->search)
             ->when(! $this->isFiltered, fn ($query) => $query->limit($this->perPage))
             ->get();
     }
@@ -50,45 +37,22 @@ class Explorer extends Component
     #[Computed]
     public function isFiltered(): bool
     {
-        return filled($this->search) || filled($this->artist) || filled($this->playlist);
+        return filled($this->search);
     }
 
     public function loadMore()
     {
-        $this->perPage += 6;
-    }
-
-    public function toggleSidebar()
-    {
-        $this->isSideBarOpen = ! $this->isSideBarOpen;
+        $this->perPage += 12;
     }
 
     public function performSearch()
     {
-        $this->perPage = 6;
+        $this->perPage = 12;
     }
 
     public function resetSearch()
     {
         $this->search = null;
-        $this->artist = null;
-        $this->playlist = null;
-        $this->perPage = 6;
-    }
-
-    public function filterByArtist(string $artistId)
-    {
-        $this->artist = $artistId;
-        $this->playlist = null;
-        $this->search = null;
-        $this->perPage = 6;
-    }
-
-    public function filterByPlaylist(string $playlistId)
-    {
-        $this->playlist = $playlistId;
-        $this->artist = null;
-        $this->search = null;
-        $this->perPage = 6;
+        $this->perPage = 12;
     }
 }

--- a/app/Livewire/Leaderboards.php
+++ b/app/Livewire/Leaderboards.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\Artist;
+use App\Models\Ranking;
+use App\Models\User;
+use Illuminate\Support\Collection;
+use Livewire\Component;
+
+class Leaderboards extends Component
+{
+    public function render()
+    {
+        return view('livewire.leaderboards', [
+            'topArtists' => $this->topArtists(),
+            'topCreators' => $this->topCreators(),
+            'biggestRankings' => $this->biggestRankings(),
+        ]);
+    }
+
+    private function topArtists(): Collection
+    {
+        return cache()->remember('leaderboards:top-artists', now()->addHour(), fn () => Artist::query()
+            ->topArtists()
+            ->get()
+            ->map(fn (Artist $artist) => [
+                'image' => $artist->artist_img,
+                'name' => $artist->artist_name,
+                'count' => $artist->artist_rankings_count,
+                'url' => null,
+                'spotify_url' => $artist->spotifyUrl(),
+            ]));
+    }
+
+    private function topCreators(): Collection
+    {
+        return cache()->remember('leaderboards:top-creators', now()->addHour(), fn () => User::query()
+            ->topCreators()
+            ->get()
+            ->map(fn (User $user) => [
+                'image' => $user->avatar,
+                'name' => $user->name,
+                'count' => $user->rankings_count,
+                'url' => route('profile', ['id' => $user->spotify_id]),
+                'spotify_url' => null,
+            ]));
+    }
+
+    private function biggestRankings(): Collection
+    {
+        return cache()->remember('leaderboards:most-songs', now()->addHour(), fn () => Ranking::query()
+            ->mostSongs()
+            ->get()
+            ->map(fn (Ranking $ranking) => [
+                'image' => $ranking->source?->cover(),
+                'name' => $ranking->name,
+                'subtitle' => $ranking->user->name,
+                'count' => $ranking->songs_count,
+                'url' => route('ranking', ['id' => $ranking->getKey()]),
+                'spotify_url' => $ranking->source?->spotifyUrl(),
+            ]));
+    }
+}

--- a/app/Livewire/Notifications/Bell.php
+++ b/app/Livewire/Notifications/Bell.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Notifications;
 
+use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 
 class Bell extends Component
@@ -10,14 +11,14 @@ class Bell extends Component
 
     public function mount(): void
     {
-        $this->unreadCount = auth()->user()->unreadNotifications()->count();
+        $this->unreadCount = Auth::user()->unreadNotifications()->count();
     }
 
     public function open(): void
     {
         if ($this->unreadCount > 0) {
-            auth()->user()->unreadNotifications->markAsRead();
-            
+            Auth::user()->unreadNotifications->markAsRead();
+
             $this->unreadCount = 0;
         }
     }
@@ -25,7 +26,7 @@ class Bell extends Component
     public function render()
     {
         return view('livewire.notifications.bell', [
-            'notifications' => auth()->user()
+            'notifications' => Auth::user()
                 ->notifications()
                 ->latest()
                 ->limit(20)

--- a/app/Livewire/Notifications/Details.php
+++ b/app/Livewire/Notifications/Details.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Notifications;
 
 use App\Models\Notification;
+use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
@@ -17,7 +18,7 @@ class Details extends Component
     {
         $this->notification = Notification::query()
             ->where('id', $notificationId)
-            ->where('notifiable_id', auth()->id())
+            ->where('notifiable_id', Auth::id())
             ->firstOrFail();
 
         $this->open = true;

--- a/app/Livewire/Notifications/ShowAll.php
+++ b/app/Livewire/Notifications/ShowAll.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Notifications;
 
+use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Title;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -14,7 +15,7 @@ class ShowAll extends Component
     public function render()
     {
         return view('livewire.notifications.show-all', [
-            'notifications' => auth()->user()->notifications()->paginate(10),
+            'notifications' => Auth::user()->notifications()->paginate(10),
         ]);
     }
 }

--- a/app/Livewire/Profile/Settings.php
+++ b/app/Livewire/Profile/Settings.php
@@ -20,7 +20,7 @@ class Settings extends Component
 
     public function updateSetting(string $name, mixed $value)
     {
-        auth()->user()->preferences()->update([
+        Auth::user()->preferences()->update([
             $name => $value,
         ]);
 
@@ -36,9 +36,9 @@ class Settings extends Component
     public function destroy($userId)
     {
         // Security check
-        abort_unless(auth()->check() && $userId == auth()->id(), 403);
+        abort_unless(Auth::check() && $userId == Auth::id(), 403);
 
-        $user = auth()->user();
+        $user = Auth::user();
 
         // Log them out
         Auth::logout();
@@ -59,11 +59,11 @@ class Settings extends Component
     public function download()
     {
         $rankings = Ranking::query()
-            ->where('user_id', auth()->id())
+            ->where('user_id', Auth::id())
             ->with('songs', 'artist')
             ->get();
 
-        $user = auth()->user();
+        $user = Auth::user();
 
         dispatch(fn () => Notification::send($user, new DownloadDataNotification($rankings)));
 

--- a/app/Livewire/Ranking/Card.php
+++ b/app/Livewire/Ranking/Card.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Ranking;
 use App\Actions\Rankings\DestroyRanking;
 use App\Exports\SongExport;
 use App\Models\Ranking;
+use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 use Maatwebsite\Excel\Facades\Excel;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -20,9 +21,9 @@ class Card extends Component
 
     public function destroy()
     {
-        abort_unless(auth()->check() && $this->ranking->user_id == auth()->id(), 403);
+        abort_unless(Auth::check() && $this->ranking->user_id == Auth::id(), 403);
 
-        (new DestroyRanking)->handle(auth()->user(), $this->ranking);
+        (new DestroyRanking)->handle(Auth::user(), $this->ranking);
 
         $this->dispatch('rankings-updated');
 
@@ -35,7 +36,7 @@ class Card extends Component
 
     public function download(): BinaryFileResponse
     {
-        abort_unless(auth()->check() && $this->ranking->user_id == auth()->id(), 403);
+        abort_unless(Auth::check() && $this->ranking->user_id == Auth::id(), 403);
 
         /* yeah, this isn't what you should do here but ima do it anyway */
         $this->skipRender();

--- a/app/Livewire/Ranking/EditRanking.php
+++ b/app/Livewire/Ranking/EditRanking.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Ranking;
 
 use App\Livewire\Forms\RankingForm;
 use App\Models\Ranking;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Livewire\Component;
 
@@ -20,14 +21,14 @@ class EditRanking extends Component
             ->find($id);
 
         if (is_null($this->ranking)) {
-            $email = auth()->check() ? auth()->user()->email : request()->ip();
+            $email = Auth::check() ? Auth::user()->email : request()->ip();
 
             Log::channel('discord_other_updates')->info("Ranking not found: Id Given: {$id} :: User Email: {$email}");
 
             abort(404);
         }
 
-        if ($this->ranking->user_id != auth()->id()) {
+        if ($this->ranking->user_id != Auth::id()) {
             abort(403, 'You are not allowed to edit this ranking.');
         }
 
@@ -54,6 +55,8 @@ class EditRanking extends Component
             'comments_enabled' => $this->form->comments_enabled === '1' || $this->form->comments_enabled === true,
             'comments_replies_enabled' => $this->form->comments_replies_enabled === '1' || $this->form->comments_replies_enabled === true,
         ]);
+
+        cache()->forget('explore:total-rankings');
 
         $this->js("window.flash({
             title: 'Ranking Updated!',

--- a/app/Livewire/Ranking/Ranking.php
+++ b/app/Livewire/Ranking/Ranking.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Ranking;
 
 use App\Models\Ranking as RankingModel;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Livewire\Component;
 
@@ -17,7 +18,7 @@ class Ranking extends Component
             ->find($id);
 
         if (is_null($this->ranking)) {
-            $email = auth()->check() ? auth()->user()->email : request()->ip();
+            $email = Auth::check() ? Auth::user()->email : request()->ip();
 
             Log::channel('discord_other_updates')->info("Ranking not found: Id Given: {$id} :: User Email: {$email}");
 

--- a/app/Livewire/SongRank/SongRankSetup.php
+++ b/app/Livewire/SongRank/SongRankSetup.php
@@ -13,6 +13,7 @@ use App\Enums\RankingType;
 use App\Livewire\Forms\RankingForm;
 use App\Models\Artist;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
 use Livewire\Attributes\On;
 use Livewire\Component;
@@ -70,7 +71,7 @@ class SongRankSetup extends Component
             return;
         }
 
-        $this->searchedArtists = (new SearchArtists)->handle(auth()->user(), $this->searchTerm);
+        $this->searchedArtists = (new SearchArtists)->handle(Auth::user(), $this->searchTerm);
 
         if (is_null($this->searchedArtists) || ($this->searchedArtists && $this->searchedArtists->isEmpty())) {
             $this->noArtistFound();
@@ -89,7 +90,7 @@ class SongRankSetup extends Component
             return;
         }
 
-        $playlistData = (new GetPlaylistTracks)->search(auth()->user(), $this->searchTerm);
+        $playlistData = (new GetPlaylistTracks)->search(Auth::user(), $this->searchTerm);
 
         if (is_null($playlistData)) {
             $this->playlistNotFound();
@@ -121,7 +122,7 @@ class SongRankSetup extends Component
             return;
         }
 
-        $showData = (new GetShowEpisodes)->search(auth()->user(), $this->searchTerm);
+        $showData = (new GetShowEpisodes)->search(Auth::user(), $this->searchTerm);
 
         if (is_null($showData)) {
             $this->showNotFound();
@@ -141,7 +142,7 @@ class SongRankSetup extends Component
 
         $this->searchedArtists = null;
 
-        $tracks = (new GetArtistSongs)->handle(auth()->user(), $artistId);
+        $tracks = (new GetArtistSongs)->handle(Auth::user(), $artistId);
 
         if (count($tracks) < 2 || is_null($tracks)) {
             $this->notEnoughTracks();
@@ -213,9 +214,9 @@ class SongRankSetup extends Component
         ];
 
         $ranking = match ($this->type) {
-            RankingType::ARTIST => (new StoreArtistRanking)->handle(auth()->user(), array_merge($attributes, ['artist' => $this->selectedArtist])),
-            RankingType::PLAYLIST => (new StorePlaylistRanking)->handle(auth()->user(), array_merge($attributes, ['playlist' => $this->selectedPlaylist])),
-            RankingType::SHOW => (new StoreShowRanking)->handle(auth()->user(), array_merge($attributes, ['show' => $this->selectedShow])),
+            RankingType::ARTIST => (new StoreArtistRanking)->handle(Auth::user(), array_merge($attributes, ['artist' => $this->selectedArtist])),
+            RankingType::PLAYLIST => (new StorePlaylistRanking)->handle(Auth::user(), array_merge($attributes, ['playlist' => $this->selectedPlaylist])),
+            RankingType::SHOW => (new StoreShowRanking)->handle(Auth::user(), array_merge($attributes, ['show' => $this->selectedShow])),
         };
 
         $this->redirect(route('ranking', ['id' => $ranking->getKey()]));

--- a/app/Livewire/Welcome/Stats.php
+++ b/app/Livewire/Welcome/Stats.php
@@ -12,22 +12,22 @@ class Stats extends Component
 {
     public static function getUserCount(): int
     {
-        return cache()->remember('welcome:stats:users', now()->addDay(), fn () => round(User::count() / 50) * 50);
+        return cache()->remember('welcome:stats:users', now()->addDay(), fn () => User::query()->roundedUserCount());
     }
 
     public static function getRankingCount(): int
     {
-        return cache()->remember('welcome:stats:rankings', now()->addDay(), fn () => Ranking::publicRankedCount());
+        return cache()->remember('welcome:stats:rankings', now()->addDay(), fn () => Ranking::query()->publicRankedCount());
     }
 
     public static function getArtistCount(): int
     {
-        return cache()->remember('welcome:stats:artists', now()->addDay(), fn () => Song::rankedArtistCount());
+        return cache()->remember('welcome:stats:artists', now()->addDay(), fn () => Song::query()->rankedArtistCount());
     }
 
     public static function getPlaylistCount(): int
     {
-        return cache()->remember('welcome:stats:playlists', now()->addDay(), fn () => Playlist::rankedPlaylistCount());
+        return cache()->remember('welcome:stats:playlists', now()->addDay(), fn () => Playlist::query()->rankedPlaylistCount());
     }
 
     public function render()

--- a/app/Models/Artist.php
+++ b/app/Models/Artist.php
@@ -3,10 +3,12 @@
 namespace App\Models;
 
 use App\Contracts\Rankable;
+use App\QueryBuilders\ArtistQueryBuilder;
 use Illuminate\Contracts\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
+#[UseEloquentBuilder(ArtistQueryBuilder::class)]
 class Artist extends Model implements Rankable
 {
     protected $fillable = [
@@ -53,27 +55,5 @@ class Artist extends Model implements Rankable
     public function spotifyUrl(): string
     {
         return "https://open.spotify.com/artist/{$this->artist_id}";
-    }
-
-    #[Scope]
-    public function topArtists(Builder $query, int $limit = 10)
-    {
-        $query->selectRaw('
-            count(rankings.artist_id) as artist_rankings_count,
-            artists.id,
-            artists.artist_name,
-            artists.artist_img
-        ')
-            ->join('rankings', function ($join) {
-                $join->on('rankings.artist_id', '=', 'artists.id')
-                    ->whereNull('rankings.deleted_at')
-                    ->where('rankings.is_ranked', true)
-                    ->where('rankings.is_public', true);
-            })
-            ->whereNotNull('artists.artist_img')
-            ->groupBy('rankings.artist_id')
-            ->orderBy('artist_rankings_count', 'desc')
-            ->orderBy('artists.artist_name', 'asc')
-            ->limit($limit);
     }
 }

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -3,11 +3,12 @@
 namespace App\Models;
 
 use App\Contracts\Rankable;
-use Illuminate\Database\Eloquent\Attributes\Scope;
-use Illuminate\Database\Eloquent\Builder;
+use App\QueryBuilders\PlaylistQueryBuilder;
+use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
+#[UseEloquentBuilder(PlaylistQueryBuilder::class)]
 class Playlist extends Model implements Rankable
 {
     protected $fillable = [
@@ -60,36 +61,5 @@ class Playlist extends Model implements Rankable
     public function spotifyUrl(): string
     {
         return "https://open.spotify.com/playlist/{$this->playlist_id}";
-    }
-
-    #[Scope]
-    public function topPlaylists(Builder $query)
-    {
-        $query->newQuery()
-            ->selectRaw('
-                count(rankings.playlist_id) as playlist_rankings_count,
-                playlists.id,
-                playlists.playlist_id,
-                playlists.name,
-                playlists.cover,
-                playlists.creator_name
-            ')
-            ->join('rankings', function ($join) {
-                $join->on('rankings.playlist_id', '=', 'playlists.id')
-                    ->whereNull('rankings.deleted_at')
-                    ->where('rankings.is_ranked', true)
-                    ->where('rankings.is_public', true);
-            })
-            ->groupBy('rankings.playlist_id')
-            ->orderBy('playlist_rankings_count', 'desc')
-            ->orderBy('playlists.name', 'asc');
-    }
-
-    public static function rankedPlaylistCount(): int
-    {
-        return round(static::query()
-            ->whereHas('rankings', fn (Builder $query) => $query->completed()->public())
-            ->distinct('playlist_id')
-            ->count() / 25) * 25;
     }
 }

--- a/app/Models/Ranking.php
+++ b/app/Models/Ranking.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Facades\Auth;
 use Kyledoesdev\Essentials\Concerns\HasStatsAfterEvents;
 use Spatie\Comments\Models\Concerns\HasComments;
 
@@ -28,7 +29,7 @@ class Ranking extends Model
         'is_ranked',
         'is_public',
         'comments_enabled',
-        'comment_replies_enabled',
+        'comments_replies_enabled',
         'completed_at',
     ];
 
@@ -39,7 +40,7 @@ class Ranking extends Model
             'is_public' => 'boolean',
             'has_podcast_episode' => 'boolean',
             'comments_enabled' => 'boolean',
-            'comment_replies_enabled' => 'boolean',
+            'comments_replies_enabled' => 'boolean',
         ];
     }
 
@@ -125,14 +126,9 @@ class Ranking extends Model
 
     /* Helpers */
 
-    public static function publicRankedCount(): int
-    {
-        return round(static::query()->completed()->public()->count() / 25) * 25;
-    }
-
     public function canBeSeen(): bool
     {
-        if ($this->user_id == auth()->id()) {
+        if ($this->user_id == Auth::id()) {
             return true;
         }
 
@@ -147,7 +143,7 @@ class Ranking extends Model
 
         $popupChance = ApplicationDashboard::first()?->popup_chance ?? 8;
 
-        return $justCompleted || (auth()->check() && rand(1, $popupChance) === 1);
+        return $justCompleted || (Auth::check() && rand(1, $popupChance) === 1);
     }
 
     /* contracts */

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use App\QueryBuilders\SongQueryBuilder;
+use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
+#[UseEloquentBuilder(SongQueryBuilder::class)]
 class Song extends Model
 {
     protected $fillable = [
@@ -32,13 +35,5 @@ class Song extends Model
     public function artist(): HasOne
     {
         return $this->hasOne(Artist::class, 'id', 'artist_id');
-    }
-
-    public static function rankedArtistCount(): int
-    {
-        return round(static::query()
-            ->whereHas('ranking', fn (Builder $query) => $query->completed()->whereNull('playlist_id')->whereNull('show_id'))
-            ->distinct('artist_id')
-            ->count() / 25) * 25;
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,8 +2,11 @@
 
 namespace App\Models;
 
+use App\QueryBuilders\UserQueryBuilder;
+use Database\Factories\UserFactory;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Panel;
+use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -16,9 +19,12 @@ use Spatie\Comments\Models\Concerns\InteractsWithComments;
 use Spatie\Comments\Models\Concerns\Interfaces\CanComment;
 use Spatie\Comments\Support\CommentatorProperties;
 
+#[UseEloquentBuilder(UserQueryBuilder::class)]
 class User extends Authenticatable implements CanComment, FilamentUser
 {
+    /** @use HasFactory<UserFactory> */
     use HasFactory;
+
     use HasStatsAfterEvents;
     use InteractsWithComments;
     use Notifiable;

--- a/app/QueryBuilders/ArtistQueryBuilder.php
+++ b/app/QueryBuilders/ArtistQueryBuilder.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\QueryBuilders;
+
+use Illuminate\Database\Eloquent\Builder;
+
+class ArtistQueryBuilder extends Builder
+{
+    public function topArtists(int $limit = 10): static
+    {
+        return $this->newQuery()
+            ->selectRaw('
+                count(rankings.artist_id) as artist_rankings_count,
+                artists.id,
+                artists.artist_id,
+                artists.artist_name,
+                artists.artist_img
+            ')
+            ->join('rankings', function ($join) {
+                $join->on('rankings.artist_id', '=', 'artists.id')
+                    ->whereNull('rankings.deleted_at')
+                    ->where('rankings.is_ranked', true)
+                    ->where('rankings.is_public', true);
+            })
+            ->whereNotNull('artists.artist_img')
+            ->groupBy('rankings.artist_id')
+            ->orderBy('artist_rankings_count', 'desc')
+            ->orderBy('artists.artist_name', 'asc')
+            ->limit($limit);
+    }
+}

--- a/app/QueryBuilders/PlaylistQueryBuilder.php
+++ b/app/QueryBuilders/PlaylistQueryBuilder.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\QueryBuilders;
+
+use Illuminate\Database\Eloquent\Builder;
+
+class PlaylistQueryBuilder extends Builder
+{
+    public function topPlaylists(): static
+    {
+        return $this->newQuery()
+            ->selectRaw('
+                count(rankings.playlist_id) as playlist_rankings_count,
+                playlists.id,
+                playlists.playlist_id,
+                playlists.name,
+                playlists.cover,
+                playlists.creator_name
+            ')
+            ->join('rankings', function ($join) {
+                $join->on('rankings.playlist_id', '=', 'playlists.id')
+                    ->whereNull('rankings.deleted_at')
+                    ->where('rankings.is_ranked', true)
+                    ->where('rankings.is_public', true);
+            })
+            ->groupBy('rankings.playlist_id')
+            ->orderBy('playlist_rankings_count', 'desc')
+            ->orderBy('playlists.name', 'asc');
+    }
+
+    public function rankedPlaylistCount(): int
+    {
+        return (int) (round($this->newQuery()
+            ->whereHas('rankings', fn (Builder $query) => $query->completed()->public())
+            ->distinct('playlist_id')
+            ->count() / 25) * 25);
+    }
+}

--- a/app/QueryBuilders/RankingQueryBuilder.php
+++ b/app/QueryBuilders/RankingQueryBuilder.php
@@ -4,15 +4,16 @@ namespace App\QueryBuilders;
 
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
 
 class RankingQueryBuilder extends Builder
 {
-    public function forExplorePage(array $filters): static
+    public function forExplorePage(?string $search = null): static
     {
         return $this->newQuery()
             ->public()
             ->completed()
-            ->when($filters['search'] ?? null, function (Builder $query, string $search) {
+            ->when($search, function (Builder $query, string $search) {
                 $query->where(fn (Builder $query) => $query
                     ->whereIn('artist_id', fn ($q) => $q
                         ->select('id')
@@ -31,15 +32,6 @@ class RankingQueryBuilder extends Builder
                     )
                 );
             })
-            ->when($filters['artist'] ?? null, fn (Builder $query, string $artist) => $query
-                ->where('artist_id', $artist)
-            )
-            ->when($filters['playlist'] ?? null, fn (Builder $query, string $playlist) => $query
-                ->where('playlist_id', $playlist)
-            )
-            ->when($filters['show'] ?? null, fn (Builder $query, string $show) => $query
-                ->where('show_id', $show)
-            )
             ->withHasPodcastEpisode()
             ->with('user', 'artist', 'playlist', 'show')
             ->with('songs', fn ($query) => $query->where('rank', 1))
@@ -50,8 +42,8 @@ class RankingQueryBuilder extends Builder
     public function forProfilePage(User $user): static
     {
         return $this->newQuery()
-            ->where('user_id', $user ? $user->getKey() : auth()->id())
-            ->when($user && $user->getKey() !== auth()->id(), fn (Builder $query) => $query->public()->completed())
+            ->where('user_id', $user ? $user->getKey() : Auth::id())
+            ->when($user && $user->getKey() !== Auth::id(), fn (Builder $query) => $query->public()->completed())
             ->withHasPodcastEpisode()
             ->with('user', 'artist', 'playlist', 'show')
             ->with('songs', fn ($query) => $query->with('artist'))
@@ -72,6 +64,29 @@ class RankingQueryBuilder extends Builder
             ->orderBy('completed_at', 'desc');
     }
 
+    public function mostSongs(int $limit = 10): static
+    {
+        return $this->newQuery()
+            ->public()
+            ->completed()
+            ->has('songs', '<=', 500)
+            ->withCount('songs')
+            ->with('user', 'artist', 'playlist', 'show')
+            ->orderByDesc('songs_count')
+            ->orderBy('name')
+            ->limit($limit);
+    }
+
+    public function publicRankedCount(): int
+    {
+        return (int) (round($this->newQuery()->completed()->public()->count() / 25) * 25);
+    }
+
+    public function explorableCount(): int
+    {
+        return $this->newQuery()->public()->completed()->count();
+    }
+
     public function withHasPodcastEpisode()
     {
         return $this->addSelect([
@@ -89,11 +104,6 @@ class RankingQueryBuilder extends Builder
     public function public(): static
     {
         return $this->where('is_public', true);
-    }
-
-    public function private(): static
-    {
-        return $this->where('is_public', false);
     }
 
     public function completed(): static

--- a/app/QueryBuilders/SongQueryBuilder.php
+++ b/app/QueryBuilders/SongQueryBuilder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\QueryBuilders;
+
+use Illuminate\Database\Eloquent\Builder;
+
+class SongQueryBuilder extends Builder
+{
+    public function rankedArtistCount(): int
+    {
+        return (int) (round($this->newQuery()
+            ->whereHas('ranking', fn (Builder $query) => $query->completed()->whereNull('playlist_id')->whereNull('show_id'))
+            ->distinct('artist_id')
+            ->count() / 25) * 25);
+    }
+}

--- a/app/QueryBuilders/UserQueryBuilder.php
+++ b/app/QueryBuilders/UserQueryBuilder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\QueryBuilders;
+
+use Illuminate\Database\Eloquent\Builder;
+
+class UserQueryBuilder extends Builder
+{
+    public function topCreators(int $limit = 10): static
+    {
+        return $this->newQuery()
+            ->whereHas('rankings', fn (Builder $query) => $query->public()->completed())
+            ->withCount(['rankings' => fn (Builder $query) => $query->public()->completed()])
+            ->orderByDesc('rankings_count')
+            ->orderBy('name')
+            ->limit($limit);
+    }
+
+    public function roundedUserCount(): int
+    {
+        return (int) (round($this->newQuery()->count() / 50) * 50);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.10",
+        "barryvdh/laravel-ide-helper": "^3.7",
         "fakerphp/faker": "^1.23",
         "filament/upgrade": "^5.0",
         "glhd/laravel-dumper": "^3.0",
@@ -39,6 +40,7 @@
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-arch": "^4.0",
         "pestphp/pest-plugin-browser": "^4.0",
+        "pestphp/pest-plugin-laravel": "^4.1",
         "spatie/laravel-ignition": "^2.4"
     },
     "repositories": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "49c56e799462078920aace20018251ce",
+    "content-hash": "dd5d2fe18158e6709b6681a47983ade0",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -12349,6 +12349,153 @@
             "time": "2026-01-23T15:03:22+00:00"
         },
         {
+            "name": "barryvdh/laravel-ide-helper",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-ide-helper.git",
+                "reference": "ad7e37676f1ff985d55ef1b6b96a0c0a40f2609a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-ide-helper/zipball/ad7e37676f1ff985d55ef1b6b96a0c0a40f2609a",
+                "reference": "ad7e37676f1ff985d55ef1b6b96a0c0a40f2609a",
+                "shasum": ""
+            },
+            "require": {
+                "barryvdh/reflection-docblock": "^2.4",
+                "composer/class-map-generator": "^1.0",
+                "ext-json": "*",
+                "illuminate/console": "^11.15 || ^12 || ^13.0",
+                "illuminate/database": "^11.15 || ^12 || ^13.0",
+                "illuminate/filesystem": "^11.15 || ^12 || ^13.0",
+                "illuminate/support": "^11.15 || ^12 || ^13.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "ext-pdo_sqlite": "*",
+                "friendsofphp/php-cs-fixer": "^3",
+                "illuminate/config": "^11.15 || ^12 || ^13.0",
+                "illuminate/view": "^11.15 || ^12 || ^13.0",
+                "larastan/larastan": "^3.1",
+                "mockery/mockery": "^1.4",
+                "orchestra/testbench": "^9.2 || ^10 || ^11.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5 || ^11.5.3 || ^12.5.12",
+                "spatie/phpunit-snapshot-assertions": "^4 || ^5",
+                "vlucas/phpdotenv": "^5"
+            },
+            "suggest": {
+                "illuminate/events": "Required for automatic helper generation (^6|^7|^8|^9|^10|^11)."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Barryvdh\\LaravelIdeHelper\\IdeHelperServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Barryvdh\\LaravelIdeHelper\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Laravel IDE Helper, generates correct PHPDocs for all Facade classes, to improve auto-completion.",
+            "keywords": [
+                "autocomplete",
+                "codeintel",
+                "dev",
+                "helper",
+                "ide",
+                "laravel",
+                "netbeans",
+                "phpdoc",
+                "phpstorm",
+                "sublime"
+            ],
+            "support": {
+                "issues": "https://github.com/barryvdh/laravel-ide-helper/issues",
+                "source": "https://github.com/barryvdh/laravel-ide-helper/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-17T14:12:51+00:00"
+        },
+        {
+            "name": "barryvdh/reflection-docblock",
+            "version": "v2.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/ReflectionDocBlock.git",
+                "reference": "4f5ba70c30c81f2ce03a16a9965832cfcc31ed3b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/ReflectionDocBlock/zipball/4f5ba70c30c81f2ce03a16a9965832cfcc31ed3b",
+                "reference": "4f5ba70c30c81f2ce03a16a9965832cfcc31ed3b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.14|^9"
+            },
+            "suggest": {
+                "dflydev/markdown": "~1.0",
+                "erusev/parsedown": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Barryvdh": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "mike.vanriel@naenius.com"
+                }
+            ],
+            "support": {
+                "source": "https://github.com/barryvdh/ReflectionDocBlock/tree/v2.4.1"
+            },
+            "time": "2026-03-05T20:09:01+00:00"
+        },
+        {
             "name": "brianium/paratest",
             "version": "v7.19.0",
             "source": {
@@ -12440,6 +12587,75 @@
                 }
             ],
             "time": "2026-02-06T10:53:26+00:00"
+        },
+        {
+            "name": "composer/class-map-generator",
+            "version": "1.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/class-map-generator.git",
+                "reference": "86d8208fc3c649a3a999daf1a63c25201be2990f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/86d8208fc3c649a3a999daf1a63c25201be2990f",
+                "reference": "86d8208fc3c649a3a999daf1a63c25201be2990f",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^2.1 || ^3.1",
+                "php": "^7.2 || ^8.0",
+                "symfony/finder": "^4.4 || ^5.3 || ^6 || ^7 || ^8"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-deprecation-rules": "^1 || ^2",
+                "phpstan/phpstan-phpunit": "^1 || ^2",
+                "phpstan/phpstan-strict-rules": "^1.1 || ^2",
+                "phpunit/phpunit": "^8",
+                "symfony/filesystem": "^5.4 || ^6 || ^7 || ^8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\ClassMapGenerator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Utilities to scan PHP code and generate class maps.",
+            "keywords": [
+                "classmap"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/class-map-generator/issues",
+                "source": "https://github.com/composer/class-map-generator/tree/1.7.3"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-05T09:17:07+00:00"
         },
         {
             "name": "daverandom/libdns",
@@ -13860,6 +14076,80 @@
                 }
             ],
             "time": "2026-02-17T14:54:40+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-laravel",
+            "version": "v4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-laravel.git",
+                "reference": "3057a36669ff11416cc0dc2b521b3aec58c488d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-laravel/zipball/3057a36669ff11416cc0dc2b521b3aec58c488d0",
+                "reference": "3057a36669ff11416cc0dc2b521b3aec58c488d0",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/framework": "^11.45.2|^12.52.0|^13.0",
+                "pestphp/pest": "^4.4.1",
+                "php": "^8.3.0"
+            },
+            "require-dev": {
+                "laravel/dusk": "^8.3.6",
+                "orchestra/testbench": "^9.13.0|^10.9.0|^11.0",
+                "pestphp/pest-dev-tools": "^4.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Laravel\\Plugin"
+                    ]
+                },
+                "laravel": {
+                    "providers": [
+                        "Pest\\Laravel\\PestServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Autoload.php"
+                ],
+                "psr-4": {
+                    "Pest\\Laravel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest Laravel Plugin",
+            "keywords": [
+                "framework",
+                "laravel",
+                "pest",
+                "php",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-laravel/tree/v4.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-21T00:29:45+00:00"
         },
         {
             "name": "pestphp/pest-plugin-mutate",

--- a/database/factories/ArtistFactory.php
+++ b/database/factories/ArtistFactory.php
@@ -2,8 +2,12 @@
 
 namespace Database\Factories;
 
+use App\Models\Artist;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
+/**
+ * @extends Factory<Artist>
+ */
 class ArtistFactory extends Factory
 {
     public function definition(): array
@@ -11,7 +15,7 @@ class ArtistFactory extends Factory
         return [
             'artist_id' => str()->random(16),
             'artist_name' => fake()->userName(),
-            'artist_img' => "https://www.gravatar.com/avatar/unknown?d=mp",
+            'artist_img' => 'https://www.gravatar.com/avatar/unknown?d=mp',
         ];
     }
 }

--- a/database/factories/FaqFactory.php
+++ b/database/factories/FaqFactory.php
@@ -2,10 +2,11 @@
 
 namespace Database\Factories;
 
+use App\Models\Faq;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Faq>
+ * @extends Factory<Faq>
  */
 class FaqFactory extends Factory
 {

--- a/database/factories/PlaylistFactory.php
+++ b/database/factories/PlaylistFactory.php
@@ -2,8 +2,12 @@
 
 namespace Database\Factories;
 
+use App\Models\Playlist;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
+/**
+ * @extends Factory<Playlist>
+ */
 class PlaylistFactory extends Factory
 {
     public function definition(): array
@@ -12,8 +16,8 @@ class PlaylistFactory extends Factory
             'playlist_id' => str()->random(16),
             'creator_id' => str()->random(16),
             'creator_name' => fake()->userName(),
-            'name' => fake()->sentance(1),
-            'description' => fake()->sentance(1),
+            'name' => fake()->sentence(1),
+            'description' => fake()->sentence(1),
             'cover' => fake()->imageUrl(200, 200, 'playlist', true),
             'track_count' => rand(5, 100),
         ];

--- a/database/factories/RankingFactory.php
+++ b/database/factories/RankingFactory.php
@@ -8,6 +8,9 @@ use App\Models\Song;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
+/**
+ * @extends Factory<Ranking>
+ */
 class RankingFactory extends Factory
 {
     public function definition(): array

--- a/database/factories/SongFactory.php
+++ b/database/factories/SongFactory.php
@@ -4,9 +4,13 @@ namespace Database\Factories;
 
 use App\Models\Artist;
 use App\Models\Ranking;
+use App\Models\Song;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
+/**
+ * @extends Factory<Song>
+ */
 class SongFactory extends Factory
 {
     public function definition(): array

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -6,6 +6,9 @@ use App\Models\User;
 use App\Models\UserPreference;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
+/**
+ * @extends Factory<User>
+ */
 class UserFactory extends Factory
 {
     public function definition(): array
@@ -14,7 +17,7 @@ class UserFactory extends Factory
             'spotify_id' => 'spotify-id-'.str()->random(32),
             'name' => fake()->username(),
             'email' => fake()->unique()->safeEmail(),
-            'avatar' => "https://www.gravatar.com/avatar/unknown?d=mp",
+            'avatar' => 'https://www.gravatar.com/avatar/unknown?d=mp',
             'timezone' => fake()->timezone(),
             'ip_address' => fake()->localIpv4(),
             'external_token' => str()->random(32),

--- a/database/factories/UserPreferenceFactory.php
+++ b/database/factories/UserPreferenceFactory.php
@@ -3,8 +3,12 @@
 namespace Database\Factories;
 
 use App\Models\User;
+use App\Models\UserPreference;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
+/**
+ * @extends Factory<UserPreference>
+ */
 class UserPreferenceFactory extends Factory
 {
     private bool $recieveNewsletterEmails = true;

--- a/resources/css/components/colors.css
+++ b/resources/css/components/colors.css
@@ -16,10 +16,26 @@
     @apply text-red-400 hover:text-red-500 text-zinc-800 mx-1;
 }
 
+@utility text-primary-icon {
+    @apply text-purple-500;
+}
+
 /* Backgrounds */
 
 @utility bg-primary {
-    @apply bg-purple-400; 
+    @apply bg-purple-400;
+}
+
+@utility bg-primary-soft {
+    @apply bg-purple-50;
+}
+
+@utility bg-primary-muted {
+    @apply bg-purple-100;
+}
+
+@utility bg-primary-accent {
+    @apply bg-purple-200;
 }
 
 @utility bg-secondary {
@@ -57,9 +73,26 @@
     animation: gradientAnimation 20s linear infinite;
 }
 
+/* Medals */
+@utility medal-gold {
+    @apply bg-amber-400 text-zinc-800;
+}
+
+@utility medal-silver {
+    @apply bg-slate-300 text-zinc-800;
+}
+
+@utility medal-bronze {
+    @apply bg-yellow-700 text-white;
+}
+
 /* Borders */
 @utility border-primary {
-    @apply border-purple-500; 
+    @apply border-purple-500;
+}
+
+@utility border-primary-soft {
+    @apply border-purple-200;
 }
 
 @utility border-secondary {

--- a/resources/views/components/leaderboards/section.blade.php
+++ b/resources/views/components/leaderboards/section.blade.php
@@ -1,0 +1,107 @@
+@props(['title', 'icon', 'entries', 'countLabel'])
+
+<div class="bg-white shadow-md rounded-xl p-4">
+    <h3 class="text-lg text-center k-line font-semibold mb-4">
+        <i class="fa-solid {{ $icon }} text-primary-icon mr-1"></i>
+        {{ $title }}
+    </h3>
+
+    {{-- Podium: #2 | #1 | #3 --}}
+    <div class="flex items-end justify-center gap-3 mb-6">
+        @foreach ([2, 1, 3] as $place)
+            @php $entry = $entries->get($place - 1); @endphp
+
+            @if ($entry)
+                @php
+                    $medal = match ($place) {
+                        1 => 'medal-gold',
+                        2 => 'medal-silver',
+                        3 => 'medal-bronze',
+                    };
+                    $size = $place === 1 ? 'w-24 h-24' : 'w-16 h-16';
+                @endphp
+
+                <div
+                    class="flex flex-col items-center w-1/3 min-w-0 {{ $place === 1 ? 'pb-4' : '' }} {{ $entry['url'] ? 'cursor-pointer' : '' }}"
+                    @if ($entry['url']) onclick="window.location.href='{{ $entry['url'] }}'" @endif
+                >
+                    @if ($entry['image'])
+                        <img
+                            src="{{ $entry['image'] }}"
+                            alt="{{ $entry['name'] }}"
+                            class="{{ $size }} rounded-xl object-cover border border-zinc-200 shadow-sm"
+                        >
+                    @else
+                        <div class="{{ $size }} rounded-xl border border-zinc-200 shadow-sm bg-primary-muted flex items-center justify-center">
+                            <i class="fa-solid {{ $icon }} text-primary-icon"></i>
+                        </div>
+                    @endif
+
+                    <span class="w-6 h-6 mt-2 rounded-full {{ $medal }} text-xs font-bold flex items-center justify-center shadow">
+                        {{ $place }}
+                    </span>
+
+                    <span class="mt-1 text-sm font-semibold truncate w-full text-center" title="{{ $entry['name'] }}">
+                        {{ $entry['name'] }}
+                    </span>
+
+                    @if ($entry['subtitle'] ?? null)
+                        <span class="text-[11px] text-zinc-400 truncate w-full text-center">
+                            by {{ $entry['subtitle'] }}
+                        </span>
+                    @endif
+
+                    <span class="text-xs text-zinc-500">
+                        {{ $entry['count'] }} {{ $countLabel }}
+                    </span>
+                </div>
+            @endif
+        @endforeach
+    </div>
+
+    {{-- Places 4-10 --}}
+    @if ($entries->count() > 3)
+        <ul class="space-y-2">
+            @foreach ($entries->slice(3) as $index => $entry)
+                <li>
+                    <div
+                        class="flex items-center gap-3 p-2 rounded-md hover:bg-gray-100 {{ $entry['url'] ? 'cursor-pointer' : '' }}"
+                        @if ($entry['url']) onclick="window.location.href='{{ $entry['url'] }}'" @endif
+                    >
+                        <span class="w-8 h-8 shrink-0 rounded-full bg-primary-accent flex items-center justify-center text-sm">
+                            {{ $index + 1 }}
+                        </span>
+
+                        @if ($entry['image'])
+                            <img
+                                src="{{ $entry['image'] }}"
+                                alt="{{ $entry['name'] }}"
+                                class="w-8 h-8 shrink-0 rounded-lg object-cover border border-zinc-200"
+                            >
+                        @else
+                            <div class="w-8 h-8 shrink-0 rounded-lg border border-zinc-200 bg-primary-muted flex items-center justify-center">
+                                <i class="fa-solid {{ $icon }} text-xs text-primary-icon"></i>
+                            </div>
+                        @endif
+
+                        <span class="flex-1 min-w-0">
+                            <span class="block truncate text-sm" title="{{ $entry['name'] }}">
+                                {{ $entry['name'] }}
+                            </span>
+
+                            @if ($entry['subtitle'] ?? null)
+                                <span class="block text-[11px] text-zinc-400 truncate">
+                                    by {{ $entry['subtitle'] }}
+                                </span>
+                            @endif
+                        </span>
+
+                        <span class="text-xs text-zinc-500 whitespace-nowrap">
+                            {{ $entry['count'] }} {{ $countLabel }}
+                        </span>
+                    </div>
+                </li>
+            @endforeach
+        </ul>
+    @endif
+</div>

--- a/resources/views/livewire/explorer.blade.php
+++ b/resources/views/livewire/explorer.blade.php
@@ -1,135 +1,79 @@
 <div>
-    <div class="min-h-screen">
-        <!-- Toggle Buttons (visible on smaller screens) -->
-        <button 
-            class="lg:hidden fixed left-0 top-1/2 -translate-y-1/2 bg-white border p-2 rounded-r-md z-50 shadow-lg"
-            wire:click="toggleSidebar"
-        >
-            <i class="fa-solid fa-angle-right"></i>
-        </button>
-
-        <div class="grid grid-cols-1 lg:grid-cols-[minmax(auto,320px)_1fr_minmax(auto,320px)] min-h-screen py-4 gap-4">
-            <!-- Left Sidebar - Artists -->
-            <div class="
-                lg:block 
-                fixed lg:static 
-                inset-0 lg:inset-auto 
-                z-40 lg:z-auto 
-                bg-black/50 lg:bg-transparent
-                transition-all duration-300 ease-in-out
-                {{ $isSideBarOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none lg:opacity-100 lg:pointer-events-auto' }}
-            ">
-                <div class="
-                    w-80 lg:w-full lg:max-w-80 
-                    h-full lg:h-auto 
-                    bg-white 
-                    shadow-md 
-                    rounded-lg 
-                    overflow-y-auto
-                    ml-0 lg:ml-0
-                    transform transition-transform duration-300 ease-in-out
-                    {{ $isSideBarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0' }}
-                ">
-                    <div class="p-4">
-                        <h3 class="text-lg text-center k-line font-semibold mb-3">
-                            Top Ranked Artists
-                        </h3>
-                        
-                        <ul class="space-y-2">
-                            @foreach ($artists as $index => $artist)
-                                @php
-                                    $color = 'w-8 h-8 rounded-full flex items-center justify-center ' . match($index + 1) {
-                                        1 => 'bg-amber-400',
-                                        2 => 'bg-slate-300',
-                                        3 => 'bg-yellow-700',
-                                        default => 'bg-purple-200'
-                                    };
-                                @endphp
-
-                                <li 
-                                    wire:key="artist-{{ $artist->getKey() }}"
-                                    class="p-2 hover:bg-gray-100 rounded-md cursor-pointer {{ $this->artist == $artist->getKey() ? 'bg-purple-100 border-l-4 border-purple-500' : '' }}"
-                                    wire:click="filterByArtist({{ $artist->getKey() }})"
-                                >
-                                    <div class="flex items-center space-x-2">
-                                        <div class="{{ $color }}">
-                                            {{ $index + 1 }}
-                                        </div>
-                                        <span>{{ $artist->artist_name }}
-                                            <span class="text-xs">({{ $artist->artist_rankings_count }})</span>
-                                        </span>
-                                    </div>
-                                </li>
-                            @endforeach
-                        </ul>
+    <div class="min-h-screen py-4">
+        <div class="w-full max-w-6xl mx-auto">
+            {{-- Header + Search --}}
+            <div class="mb-4 bg-white rounded-lg shadow-sm p-4 border border-gray-200">
+                <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                    <div class="whitespace-nowrap">
+                        <h2 class="text-lg font-semibold text-zinc-800">
+                            <i class="fa fa-compass text-primary-icon mr-1"></i>
+                            Explore Rankings
+                        </h2>
+                        <p class="text-xs text-zinc-500 mt-0.5">
+                            {{ number_format($totalRankings) }} completed {{ Str::plural('ranking', $totalRankings) }} to explore
+                        </p>
                     </div>
-                </div>
 
-                <!-- Overlay click area (mobile only) -->
-                <div class="lg:hidden absolute inset-0 -z-10" wire:click="toggleSidebar"></div>
+                    <form wire:submit="performSearch" class="flex items-center gap-2 w-full sm:w-auto">
+                        <div class="relative flex-1 sm:flex-none sm:w-80">
+                            <i class="fa fa-magnifying-glass absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400 text-sm"></i>
+                            <input
+                                class="w-full pl-9 pr-3 py-2 text-sm border border-zinc-300 rounded-full transition-all duration-300 focus:ring-2 focus:ring-purple-400 focus:border-purple-400 focus:outline-none"
+                                type="text"
+                                placeholder="Search by name, artist or playlist"
+                                wire:model="search"
+                            />
+                        </div>
+
+                        <button
+                            type="submit"
+                            class="btn-primary px-3 py-1.5 cursor-pointer transform transition-all duration-300 hover:scale-110 active:scale-95"
+                            title="Search"
+                        >
+                            <i class="fa fa-magnifying-glass mt-1"></i>
+                        </button>
+
+                        <button
+                            type="button"
+                            class="btn-secondary px-3 py-1.5 cursor-pointer transform transition-all duration-300 hover:scale-110 active:scale-95"
+                            wire:click="resetSearch"
+                            title="Reset search"
+                        >
+                            <i class="fa-solid fa-rotate-left mt-1"></i>
+                        </button>
+                    </form>
+                </div>
             </div>
 
-            <!-- Main Content -->
-            <div class="w-full max-w-4xl lg:mx-auto">
-                <!-- Search Section -->
-                <div class="mb-4 bg-white rounded-lg shadow-sm p-4 border border-gray-200">
-                    <div class="flex flex-col sm:flex-row items-center w-full space-y-2 sm:space-y-0 sm:space-x-2">
-                        <input 
-                            class="w-full sm:flex-1 p-2 border rounded-lg transition-all duration-300 focus:ring-2 focus:ring-purple-400 border-zinc-800" 
-                            type="text" 
-                            placeholder="Search rankings by name, artist or playlist" 
-                            wire:model="search"
-                        />
-                        <div class="flex space-x-2">
-                            <button 
-                                type="button" 
-                                class="btn-primary px-2 py-1 cursor-pointer transform transition-all duration-300 hover:scale-110 active:scale-95" 
-                                wire:click="performSearch"
-                            >
-                                <i class="text-lg fa fa-magnifying-glass mt-1"></i>
-                            </button>
-
-                            <button 
-                                type="button" 
-                                class="btn-secondary px-2 py-1 cursor-pointer transform transition-all duration-300 hover:scale-110 active:scale-95" 
-                                wire:click="resetSearch"
-                            >
-                                <i class="text-lg fa-solid fa-rotate-left mt-1"></i>
-                            </button>
+            {{-- wire:intersect triggers loadMore on scroll, incrementing $perPage so the --}}
+            {{-- full list re-renders with more results. Searching resets $perPage to 12. --}}
+            @if ($this->rankings->count())
+                <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                    @foreach ($this->rankings as $ranking)
+                        <div
+                            class="rounded-md cursor-pointer p-1 transform transition-all duration-300 hover:scale-101"
+                            wire:key="ranking-{{ $ranking->getKey() }}"
+                            wire:transition
+                        >
+                            <x-ranking-card :ranking="$ranking" />
                         </div>
-                    </div>
+                    @endforeach
                 </div>
 
-                {{-- wire:intersect triggers loadMore on scroll, incrementing $perPage so the --}}
-                {{-- full list re-renders with more results. Filters reset $perPage to 10. --}}
-                @if ($this->rankings->count())
-                    <div class="flex flex-col space-y-4">
-                        @foreach ($this->rankings as $ranking)
-                            <div 
-                                class="rounded-md cursor-pointer p-1 transform transition-all duration-300 hover:scale-101"
-                                wire:key="ranking-{{ $ranking->getKey() }}"
-                                wire:transition
-                            >
-                                <x-ranking-card :ranking="$ranking" />
-                            </div>
-                        @endforeach
-                    </div>
-
-                    @if ($this->hasMorePages && ! $this->isFiltered)
-                        <div wire:intersect="loadMore" class="mt-4 flex justify-center">
-                            <div class="animate-pulse space-y-4 w-full">
-                                @foreach (range(1, 4) as $_)
-                                    <x-ranking-card-placeholder wire:transition />
-                                @endforeach
-                            </div>
+                @if ($this->hasMorePages && ! $this->isFiltered)
+                    <div wire:intersect="loadMore" class="mt-4">
+                        <div class="animate-pulse grid grid-cols-1 lg:grid-cols-2 gap-4">
+                            @foreach (range(1, 4) as $_)
+                                <x-ranking-card-placeholder wire:transition />
+                            @endforeach
                         </div>
-                    @endif
-                @else
-                    <div class="flex justify-center">
-                        <span>No rankings found.</span>
                     </div>
                 @endif
-            </div>
+            @else
+                <div class="flex justify-center">
+                    <span>No rankings found.</span>
+                </div>
+            @endif
         </div>
     </div>
 </div>

--- a/resources/views/livewire/leaderboards.blade.php
+++ b/resources/views/livewire/leaderboards.blade.php
@@ -1,0 +1,28 @@
+<div>
+    <div class="min-h-screen py-4">
+        <div class="w-full max-w-6xl mx-auto">
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 items-start">
+                <x-leaderboards.section
+                    title="Top Ranked Artists"
+                    icon="fa-music"
+                    :entries="$topArtists"
+                    count-label="rankings"
+                />
+
+                <x-leaderboards.section
+                    title="Top Creators"
+                    icon="fa-user"
+                    :entries="$topCreators"
+                    count-label="rankings"
+                />
+
+                <x-leaderboards.section
+                    title="Rankings with Most Songs"
+                    icon="fa-list-ol"
+                    :entries="$biggestRankings"
+                    count-label="songs"
+                />
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/navigation.blade.php
+++ b/resources/views/livewire/navigation.blade.php
@@ -41,19 +41,25 @@
             </div>
 
             <nav class="flex-1 px-4 py-4 space-y-2">
+                @if (Route::currentRouteName() !== 'explore')
+                    <a href="{{ route('explore') }}" class="flex items-center px-3 py-2 text-sm font-medium text-zinc-800 rounded-md hover:bg-gray-100">
+                        <i class="fa fa-compass mr-3"></i>
+                        Explore
+                    </a>
+                @endif
+                @if (Route::currentRouteName() !== 'leaderboards')
+                    <a href="{{ route('leaderboards') }}" class="flex items-center px-3 py-2 text-sm font-medium text-zinc-800 rounded-md hover:bg-gray-100">
+                        <i class="fa fa-trophy mr-3"></i>
+                        Leaderboards
+                    </a>
+                @endif
                 @auth
-                    @if (Route::currentRouteName() !== 'explore')
-                        <a href="{{ route('explore') }}" class="flex items-center px-3 py-2 text-sm font-medium text-zinc-800 rounded-md hover:bg-gray-100">
-                            <i class="fa fa-compass mr-3"></i>
-                            Explore
-                        </a>
-                    @endif
-                    @if (Route::currentRouteName() != 'profile' || (Route::currentRouteName() == 'profile' && Route::current()->parameter('id') != auth()->user()?->spotify_id))
+                    {{-- @if (Route::currentRouteName() != 'profile' || (Route::currentRouteName() == 'profile' && Route::current()->parameter('id') != auth()->user()?->spotify_id))
                         <a href="{{ route('profile', ['id' => auth()->user()->spotify_id ]) }}" class="flex items-center px-3 py-2 text-sm font-medium text-zinc-800 rounded-md hover:bg-gray-100">
                             <i class="fa fa-user mr-3"></i>
                             Profile
                         </a>
-                    @endif
+                    @endif --}}
                     @if (Route::currentRouteName() != 'settings')
                         <a href="{{ route('settings') }}" class="flex items-center px-3 py-2 text-sm font-medium text-zinc-800 rounded-md hover:bg-gray-100">
                             <i class="fa fa-cog mr-3"></i>
@@ -93,8 +99,13 @@
                     </a>
 
                     <a href="{{ route('explore') }}" class="h-10 flex items-center me-4 rounded-lg cursor-pointer p-2 {{ Route::currentRouteName() == 'explore' ? 'bg-purple-100 border-b-3 border-purple-400' : 'bg-gray-100' }}">
-                        <i class="fa fa-compass mr-1 fa-lg"></i>
-                        <span class="text-sm font-medium text-zinc-800 mx-1">Explore</span>
+                        <i class="fa fa-compass mr-1"></i>
+                        <span class="text-xs font-medium text-zinc-800 mx-1">Explore</span>
+                    </a>
+
+                    <a href="{{ route('leaderboards') }}" class="h-10 flex items-center me-4 rounded-lg cursor-pointer p-2 {{ Route::currentRouteName() == 'leaderboards' ? 'bg-purple-100 border-b-3 border-purple-400' : 'bg-gray-100' }}">
+                        <i class="fa fa-trophy mr-1"></i>
+                        <span class="text-xs font-medium text-zinc-800 mx-1">Leaderboards</span>
                     </a>
                 </div>
                 
@@ -178,11 +189,9 @@
 
         <!-- Mobile top bar with hamburger -->
         <div class="lg:hidden flex justify-between items-center shadow-md bg-white p-4 rounded-lg">
-            @auth
-                <button x-on:click="sidebarOpen = true" class="text-zinc-800">
-                    <i class="fa fa-bars fa-lg"></i>
-                </button>
-            @endauth
+            <button x-on:click="sidebarOpen = true" class="text-zinc-800">
+                <i class="fa fa-bars fa-lg"></i>
+            </button>
             
             <a href="{{ auth()->check() ? route('dashboard') : route('welcome') }}" class="flex items-center">
                 <img src="/images/logo.png" alt="Song Rank Logo" class="h-8 w-8 rounded-2xl" />

--- a/resources/views/livewire/profile/profile.blade.php
+++ b/resources/views/livewire/profile/profile.blade.php
@@ -1,4 +1,4 @@
-<div class="mt-4">
+<div class="w-full max-w-6xl mx-auto mt-4">
     <x-profile-card :user="$user" />
 
     <div class="{{ $this->rankings->count() > 1 ? 'grid grid-cols-1 md:grid-cols-2 gap-4 overflow-x-auto pt-2' : 'grid grid-cols-1 gap-4 overflow-x-auto pt-2' }}">

--- a/resources/views/livewire/ranking/card.blade.php
+++ b/resources/views/livewire/ranking/card.blade.php
@@ -1,5 +1,5 @@
-<div 
-    class="bg-white shadow-md rounded-lg cursor-pointer hover:shadow-lg transition-shadow relative p-2"
+<div
+    class="relative"
     :key="'card-'.$ranking->getKey()"
 >
     <x-ranking-card :ranking="$ranking" />

--- a/resources/views/livewire/ranking/ranking.blade.php
+++ b/resources/views/livewire/ranking/ranking.blade.php
@@ -33,6 +33,38 @@
 
             <hr>
 
+            @if (auth()->id() !== $ranking->user_id)
+                <div class="mx-2 md:mx-4 mt-4 bg-primary-soft border border-primary-soft rounded-lg p-3 flex items-center gap-3">
+                    @if ($ranking->user->avatar)
+                        <img
+                            src="{{ $ranking->user->avatar }}"
+                            alt="{{ $ranking->user->name }}"
+                            class="h-10 w-10 rounded-full object-cover shrink-0"
+                        >
+                    @else
+                        <div class="h-10 w-10 rounded-full bg-primary-muted flex items-center justify-center shrink-0">
+                            <i class="fa-regular fa-user text-primary-icon"></i>
+                        </div>
+                    @endif
+
+                    <div class="min-w-0 flex-1">
+                        <p class="text-sm font-medium text-zinc-800 truncate">
+                            Ranked by
+                            <a href="{{ route('profile', ['id' => $ranking->user->spotify_id]) }}" class="text-primary hover:underline">
+                                {{ $ranking->user->name }}
+                                <i class="fa fa-arrow-up-right-from-square text-blue-500 text-xs"></i>
+                            </a>
+                        </p>
+                        <p class="text-xs text-zinc-500 truncate" title="{{ $ranking->formatted_completed_at }}">
+                            {{ $ranking->songs->count() }} {{ $ranking->type->itemLabel() }}
+                            <span class="text-zinc-300 mx-1">|</span>
+                            <i class="fa-regular fa-clock mr-0.5"></i>
+                            {{ $ranking->completed_at }}
+                        </p>
+                    </div>
+                </div>
+            @endif
+
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8 px-2 md:px-4 overflow-x-hidden">
                 <div class="md:col-span-2 w-full m-2" style="max-height: 600px; overflow-y: auto;">
                     <ol>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Livewire\About;
 use App\Livewire\Dashboard\Dashboard;
 use App\Livewire\Explorer;
 use App\Livewire\Faq;
+use App\Livewire\Leaderboards;
 use App\Livewire\Notifications\ShowAll as Notifications;
 use App\Livewire\Profile\Profile;
 use App\Livewire\Profile\Settings;
@@ -24,6 +25,7 @@ Route::livewire('/faq', Faq::class)->name('faq');
 Route::livewire('/support', Support::class)->name('support');
 
 Route::livewire('/explore', Explorer::class)->name('explore');
+Route::livewire('/leaderboards', Leaderboards::class)->name('leaderboards');
 
 Route::livewire('/rank/{id}', Ranking::class)->name('ranking');
 Route::livewire('/profile/{id}', Profile::class)->name('profile');

--- a/tests/Feature/ArchTest.php
+++ b/tests/Feature/ArchTest.php
@@ -1,27 +1,4 @@
 <?php
 
-use App\Models\Ranking;
-use App\Models\User;
-
 arch('System: Uses PHP preset')->preset()->php();
 arch('System: Uses no debug methods')->expect(['dd', 'dump', 'die', 'ray'])->not->toBeUsed();
-
-/* failing in CI - fix me later */
-
-/* it('loads all pages with no smoke', function() {
-    $user = User::factory()->create();
-
-    $this->actingAs($user);
-
-    $ranking = Ranking::factory()->create(['user_id' => $user->getKey()]);
-
-    visit([
-        '/',
-        '/about',
-        '/explore',
-        '/dashboard',
-        '/rank/'.$ranking->getKey(),
-        '/rank/'.$ranking->getKey().'/edit',
-        '/settings',
-    ])->assertNoSmoke();
-}); */

--- a/tests/Feature/ExplorePageTest.php
+++ b/tests/Feature/ExplorePageTest.php
@@ -1,66 +1,165 @@
 <?php
 
+use App\Actions\CompleteSongRankProcess;
+use App\Livewire\Explorer;
+use App\Models\Artist;
+use App\Models\Playlist;
 use App\Models\Ranking;
-use App\Models\User;
+use App\Models\RankingSortingState;
+use App\Models\Show;
+use Livewire\Livewire;
 
-test('can explore public completed rankings on explore page', function () {
-    $user = User::factory()->create();
+use function Pest\Laravel\get;
 
-    $ranking = Ranking::factory()->create([
-        'user_id' => $user->getKey(),
-        'is_public' => true,
-        'is_ranked' => true,
-        'completed_at' => now(),
-    ]);
+describe('ranking visibility', function () {
+    test('public completed rankings are visible', function () {
+        $ranking = publicCompletedRanking();
 
-    $this->actingAs($user)
-        ->get(route('explore'))
-        ->assertOk()
-        ->assertSee($user->rankings->first()->name);
+        get(route('explore'))
+            ->assertOk()
+            ->assertSee($ranking->name);
+    });
+
+    test('public uncompleted rankings are hidden', function () {
+        $ranking = Ranking::factory()->create([
+            'is_public' => true,
+            'is_ranked' => false,
+            'completed_at' => null,
+        ]);
+
+        get(route('explore'))
+            ->assertOk()
+            ->assertDontSee($ranking->name);
+    });
+
+    test('private completed rankings are hidden', function () {
+        $ranking = Ranking::factory()->create([
+            'is_public' => false,
+            'is_ranked' => true,
+            'completed_at' => now(),
+        ]);
+
+        get(route('explore'))
+            ->assertOk()
+            ->assertDontSee($ranking->name);
+    });
+
+    test('private uncompleted rankings are hidden', function () {
+        $ranking = Ranking::factory()->create([
+            'is_public' => false,
+            'is_ranked' => false,
+            'completed_at' => null,
+        ]);
+
+        get(route('explore'))
+            ->assertOk()
+            ->assertDontSee($ranking->name);
+    });
 });
 
-test('can not explore public uncompleted rankings on explore page', function () {
-    $user = User::factory()->create();
+describe('explorable rankings counter', function () {
+    test('shows a live count of explorable rankings', function () {
+        publicCompletedRanking();
+        publicCompletedRanking();
 
-    $ranking = Ranking::factory()->create([
-        'user_id' => $user->getKey(),
-        'is_public' => true,
-        'is_ranked' => false,
-        'completed_at' => null,
-    ]);
+        Ranking::factory()->create([
+            'is_public' => false,
+            'is_ranked' => true,
+            'completed_at' => now(),
+        ]);
 
-    $this->actingAs($user)
-        ->get(route('explore'))->assertOk()
-        ->assertDontSee($user->rankings->first()->name);
+        Ranking::factory()->create([
+            'is_public' => true,
+            'is_ranked' => false,
+            'completed_at' => null,
+        ]);
+
+        get(route('explore'))
+            ->assertOk()
+            ->assertSee('2 completed rankings to explore');
+    });
+
+    test('completing a ranking busts the counter cache', function () {
+        cache()->put('explore:total-rankings', 99);
+
+        $ranking = Ranking::factory()->create([
+            'is_public' => true,
+            'is_ranked' => false,
+            'completed_at' => null,
+        ]);
+
+        RankingSortingState::create(['ranking_id' => $ranking->getKey()]);
+
+        (new CompleteSongRankProcess)->handle($ranking, [
+            'finalSongIds' => $ranking->songs()->pluck('id')->all(),
+        ]);
+
+        expect(cache()->has('explore:total-rankings'))->toBeFalse();
+    });
 });
 
-test('can not explore private completed rankings on explore page', function () {
-    $user = User::factory()->create();
+describe('searching', function () {
+    test('can search rankings by artist name', function () {
+        $match = Artist::factory()->create(['artist_name' => 'Matching Artist']);
+        $other = Artist::factory()->create(['artist_name' => 'Other Artist']);
 
-    $ranking = Ranking::factory()->create([
-        'user_id' => $user->getKey(),
-        'is_public' => false,
-        'is_ranked' => true,
-        'completed_at' => now(),
-    ]);
+        $matchingRanking = publicCompletedRanking([
+            'artist_id' => $match->getKey(),
+            'name' => 'Matching Ranking',
+        ]);
 
-    $this->actingAs($user)
-        ->get(route('explore'))
-        ->assertOk()
-        ->assertDontSee($user->rankings->first()->name);
-});
+        $otherRanking = publicCompletedRanking([
+            'artist_id' => $other->getKey(),
+            'name' => 'Other Ranking',
+        ]);
 
-test('can not explore private uncompleted rankings on explore page', function () {
-    $user = User::factory()->create();
+        Livewire::test(Explorer::class)
+            ->set('search', 'Matching Artist')
+            ->call('performSearch')
+            ->assertSee($matchingRanking->name)
+            ->assertDontSee($otherRanking->name);
+    });
 
-    $ranking = Ranking::factory()->create([
-        'user_id' => $user->getKey(),
-        'is_public' => false,
-        'is_ranked' => false,
-        'completed_at' => null,
-    ]);
+    test('can search rankings by playlist name', function () {
+        $playlist = Playlist::factory()->create(['name' => 'Chill Vibes Playlist']);
 
-    $this->actingAs($user)->get(route('explore'))
-        ->assertOk()
-        ->assertDontSee($user->rankings->first()->name);
+        $matchingRanking = publicCompletedRanking([
+            'artist_id' => null,
+            'playlist_id' => $playlist->getKey(),
+            'name' => 'Matching Playlist Ranking',
+        ]);
+
+        $otherRanking = publicCompletedRanking(['name' => 'Other Ranking']);
+
+        Livewire::test(Explorer::class)
+            ->set('search', 'Chill Vibes')
+            ->call('performSearch')
+            ->assertSee($matchingRanking->name)
+            ->assertDontSee($otherRanking->name);
+    });
+
+    test('can search rankings by show name', function () {
+        $show = Show::create([
+            'show_id' => str()->random(16),
+            'publisher' => 'Podcast Publisher',
+            'name' => 'True Crime Weekly',
+            'description' => 'A weekly true crime show.',
+            'cover' => 'https://example.com/cover.jpg',
+            'episode_count' => 100,
+        ]);
+
+        $matchingRanking = publicCompletedRanking([
+            'artist_id' => null,
+            'show_id' => $show->getKey(),
+            'name' => 'Matching Show Ranking',
+        ]);
+
+        $otherRanking = publicCompletedRanking(['name' => 'Other Ranking']);
+
+        Livewire::test(Explorer::class)
+            ->set('search', 'True Crime Weekly')
+            ->call('performSearch')
+            ->assertSee($matchingRanking->name)
+            ->assertDontSee($otherRanking->name);
+    });
 });

--- a/tests/Feature/FaqPageTest.php
+++ b/tests/Feature/FaqPageTest.php
@@ -2,58 +2,56 @@
 
 use App\Models\Faq;
 
-test('faq page loads successfully', function () {
-    $this->get(route('faq'))->assertOk();
+use function Pest\Laravel\get;
+
+describe('faq page', function () {
+    test('displays active faqs', function () {
+        Faq::factory()->create([
+            'question' => 'How do I rank songs?',
+            'text' => '<p>Select an artist and start comparing!</p>',
+            'is_active' => true,
+        ]);
+
+        get(route('faq'))
+            ->assertOk()
+            ->assertSee('How do I rank songs?')
+            ->assertSee('Select an artist and start comparing!');
+    });
+
+    test('does not display inactive faqs', function () {
+        Faq::factory()->inactive()->create([
+            'question' => 'Hidden question',
+        ]);
+
+        get(route('faq'))
+            ->assertOk()
+            ->assertDontSee('Hidden question');
+    });
+
+    test('displays faqs in order', function () {
+        Faq::factory()->create(['question' => 'Second question', 'order' => 2]);
+        Faq::factory()->create(['question' => 'First question', 'order' => 1]);
+
+        $content = get(route('faq'))->assertOk()->getContent();
+
+        expect(strpos($content, 'First question'))->toBeLessThan(strpos($content, 'Second question'));
+    });
+
+    test('shows an empty state when no faqs exist', function () {
+        Faq::query()->forceDelete();
+
+        get(route('faq'))
+            ->assertOk()
+            ->assertSee('No FAQs available at this time.');
+    });
 });
 
-test('faq page displays active faqs', function () {
-    $faq = Faq::factory()->create([
-        'question' => 'How do I rank songs?',
-        'text' => '<p>Select an artist and start comparing!</p>',
-        'is_active' => true,
-    ]);
+describe('faq model', function () {
+    test('slug is auto-generated from question on create', function () {
+        $faq = Faq::factory()->create([
+            'question' => 'How do I rank songs?',
+        ]);
 
-    $this->get(route('faq'))
-        ->assertOk()
-        ->assertSee('How do I rank songs?')
-        ->assertSee('Select an artist and start comparing!');
-});
-
-test('faq page does not display inactive faqs', function () {
-    $faq = Faq::factory()->inactive()->create([
-        'question' => 'Hidden question',
-    ]);
-
-    $this->get(route('faq'))
-        ->assertOk()
-        ->assertDontSee('Hidden question');
-});
-
-test('faqs are displayed in order', function () {
-    Faq::factory()->create(['question' => 'Second question', 'order' => 2]);
-    Faq::factory()->create(['question' => 'First question', 'order' => 1]);
-
-    $response = $this->get(route('faq'))->assertOk();
-
-    $content = $response->getContent();
-    $firstPos = strpos($content, 'First question');
-    $secondPos = strpos($content, 'Second question');
-
-    expect($firstPos)->toBeLessThan($secondPos);
-});
-
-test('faq page shows empty state when no faqs exist', function () {
-    Faq::query()->forceDelete();
-
-    $this->get(route('faq'))
-        ->assertOk()
-        ->assertSee('No FAQs available at this time.');
-});
-
-test('slug is auto-generated from question on create', function () {
-    $faq = Faq::factory()->create([
-        'question' => 'How do I rank songs?',
-    ]);
-
-    expect($faq->slug)->toBe('how-do-i-rank-songs?');
+        expect($faq->slug)->toBe('how-do-i-rank-songs?');
+    });
 });

--- a/tests/Feature/LeaderboardsPageTest.php
+++ b/tests/Feature/LeaderboardsPageTest.php
@@ -1,0 +1,200 @@
+<?php
+
+use App\Livewire\Leaderboards;
+use App\Models\Artist;
+use App\Models\Playlist;
+use App\Models\Ranking;
+use App\Models\Show;
+use App\Models\Song;
+use App\Models\User;
+use Livewire\Livewire;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+describe('page access', function () {
+    test('guests can view the leaderboards page', function () {
+        get(route('leaderboards'))
+            ->assertOk()
+            ->assertSee('Top Ranked Artists')
+            ->assertSee('Top Creators')
+            ->assertSee('Rankings with Most Songs');
+    });
+
+    test('authenticated users can view the leaderboards page', function () {
+        actingAs(User::factory()->createOne())
+            ->get(route('leaderboards'))
+            ->assertOk()
+            ->assertSee('Top Ranked Artists')
+            ->assertSee('Top Creators')
+            ->assertSee('Rankings with Most Songs');
+    });
+
+    test('leaderboard entries are visible on the page', function () {
+        $artist = Artist::factory()->create(['artist_name' => 'Page Artist']);
+        $user = User::factory()->createOne(['name' => 'Page Creator']);
+
+        publicCompletedRanking([
+            'artist_id' => $artist->getKey(),
+            'user_id' => $user->getKey(),
+            'name' => 'Page Ranking',
+        ]);
+
+        get(route('leaderboards'))
+            ->assertOk()
+            ->assertSee('Page Artist')
+            ->assertSee('Page Creator')
+            ->assertSee('Page Ranking');
+    });
+
+    test('guests see the leaderboards link in the navigation', function () {
+        get(route('explore'))
+            ->assertOk()
+            ->assertSee('Leaderboards');
+    });
+});
+
+describe('top ranked artists', function () {
+    test('artists are ordered by public completed ranking count', function () {
+        $first = Artist::factory()->create(['artist_name' => 'First Artist']);
+        $second = Artist::factory()->create(['artist_name' => 'Second Artist']);
+
+        publicCompletedRanking(['artist_id' => $first->getKey()]);
+        publicCompletedRanking(['artist_id' => $first->getKey()]);
+        publicCompletedRanking(['artist_id' => $second->getKey()]);
+
+        Livewire::test(Leaderboards::class)
+            ->assertViewHas('topArtists', fn ($entries) => $entries->pluck('name')->all() === ['First Artist', 'Second Artist']
+                && $entries->first()['count'] == 2);
+    });
+
+    test('artists with only private or uncompleted rankings are not on the leaderboard', function () {
+        $private = Artist::factory()->create(['artist_name' => 'Private Artist']);
+        $unfinished = Artist::factory()->create(['artist_name' => 'Unfinished Artist']);
+
+        Ranking::factory()->create([
+            'artist_id' => $private->getKey(),
+            'is_public' => false,
+            'is_ranked' => true,
+            'completed_at' => now(),
+        ]);
+
+        Ranking::factory()->create([
+            'artist_id' => $unfinished->getKey(),
+            'is_public' => true,
+            'is_ranked' => false,
+            'completed_at' => null,
+        ]);
+
+        Livewire::test(Leaderboards::class)
+            ->assertViewHas('topArtists', fn ($entries) => $entries->isEmpty());
+    });
+});
+
+describe('top creators', function () {
+    test('creators are ordered by public completed ranking count and private-only creators are excluded', function () {
+        $prolific = User::factory()->createOne(['name' => 'Prolific Creator']);
+        $casual = User::factory()->createOne(['name' => 'Casual Creator']);
+        $private = User::factory()->createOne(['name' => 'Private Creator']);
+
+        publicCompletedRanking(['user_id' => $prolific->getKey()]);
+        publicCompletedRanking(['user_id' => $prolific->getKey()]);
+        publicCompletedRanking(['user_id' => $casual->getKey()]);
+
+        Ranking::factory()->create([
+            'user_id' => $private->getKey(),
+            'is_public' => false,
+            'is_ranked' => true,
+            'completed_at' => now(),
+        ]);
+
+        Livewire::test(Leaderboards::class)
+            ->assertViewHas('topCreators', fn ($entries) => $entries->pluck('name')->all() === ['Prolific Creator', 'Casual Creator']);
+    });
+
+    test('sections are capped at ten entries with ties broken by name', function () {
+        foreach (range('a', 'k') as $letter) {
+            $user = User::factory()->createOne(['name' => "creator-{$letter}"]);
+
+            publicCompletedRanking(['user_id' => $user->getKey()]);
+        }
+
+        Livewire::test(Leaderboards::class)
+            ->assertViewHas('topCreators', fn ($entries) => $entries->count() === 10
+                && $entries->first()['name'] === 'creator-a'
+                && ! $entries->contains('name', 'creator-k'));
+    });
+});
+
+describe('rankings with most songs', function () {
+    test('rankings are ordered by song count and credit their creator', function () {
+        $creator = User::factory()->createOne(['name' => 'List Maker']);
+
+        $bigger = publicCompletedRanking([
+            'user_id' => $creator->getKey(),
+            'name' => 'Bigger Ranking',
+        ]);
+
+        publicCompletedRanking([
+            'artist_id' => null,
+            'playlist_id' => Playlist::factory(),
+            'name' => 'Smaller Ranking',
+        ]);
+
+        foreach (range(11, 15) as $rank) {
+            Song::factory()->create([
+                'ranking_id' => $bigger->getKey(),
+                'rank' => $rank,
+            ]);
+        }
+
+        Livewire::test(Leaderboards::class)
+            ->assertViewHas('biggestRankings', fn ($entries) => $entries->pluck('name')->all() === ['Bigger Ranking', 'Smaller Ranking']
+                && $entries->first()['count'] == 15
+                && $entries->first()['subtitle'] === 'List Maker'
+                && filled($entries->last()['image']));
+    });
+
+    test('show rankings are included', function () {
+        $show = Show::create([
+            'show_id' => str()->random(16),
+            'publisher' => 'Podcast Publisher',
+            'name' => 'A Podcast Show',
+            'description' => 'A show about things.',
+            'cover' => 'https://example.com/cover.jpg',
+            'episode_count' => 100,
+        ]);
+
+        publicCompletedRanking([
+            'artist_id' => null,
+            'show_id' => $show->getKey(),
+            'name' => 'Show Ranking',
+        ]);
+
+        publicCompletedRanking(['name' => 'Music Ranking']);
+
+        Livewire::test(Leaderboards::class)
+            ->assertViewHas('biggestRankings', fn ($entries) => $entries->pluck('name')->all() === ['Music Ranking', 'Show Ranking']);
+    });
+
+    test('rankings with more than 500 songs are excluded', function () {
+        $artist = Artist::factory()->create();
+
+        $within = publicCompletedRanking(['name' => 'Within Limit Ranking']);
+        $beyond = publicCompletedRanking(['name' => 'Beyond Limit Ranking']);
+
+        Song::factory()->count(490)->create([
+            'ranking_id' => $within->getKey(),
+            'artist_id' => $artist->getKey(),
+        ]);
+
+        Song::factory()->count(491)->create([
+            'ranking_id' => $beyond->getKey(),
+            'artist_id' => $artist->getKey(),
+        ]);
+
+        Livewire::test(Leaderboards::class)
+            ->assertViewHas('biggestRankings', fn ($entries) => $entries->pluck('name')->all() === ['Within Limit Ranking']
+                && $entries->first()['count'] == 500);
+    });
+});

--- a/tests/Feature/LoginsWidgetTest.php
+++ b/tests/Feature/LoginsWidgetTest.php
@@ -5,36 +5,38 @@ use App\Models\User;
 use Kyledoesdev\Essentials\Stats\LoginStat;
 use Livewire\Livewire;
 
-test('user stats widget renders all stats', function () {
-    $user = User::factory()->create(['timezone' => 'UTC']);
+describe('logins widget', function () {
+    test('renders all stats', function () {
+        $user = User::factory()->createOne(['timezone' => 'UTC']);
 
-    Livewire::actingAs($user)
-        ->test(LoginsWidget::class)
-        ->assertSee('Total Users')
-        ->assertSee('Deleted Users')
-        ->assertSee('Daily Active Users')
-        ->assertSee('Weekly Active Users')
-        ->assertSee('Monthly Active Users');
-});
+        Livewire::actingAs($user)
+            ->test(LoginsWidget::class)
+            ->assertSee('Total Users')
+            ->assertSee('Deleted Users')
+            ->assertSee('Daily Active Users')
+            ->assertSee('Weekly Active Users')
+            ->assertSee('Monthly Active Users');
+    });
 
-test('user stats widget counts total and deleted users', function () {
-    $actor = User::factory()->create(['timezone' => 'UTC']);
-    User::factory()->count(2)->create();
-    User::factory()->count(3)->create()->each->delete();
+    test('counts total and deleted users', function () {
+        $actor = User::factory()->createOne(['timezone' => 'UTC']);
+        User::factory()->count(2)->create();
+        User::factory()->count(3)->create()->each->delete();
 
-    Livewire::actingAs($actor)
-        ->test(LoginsWidget::class)
-        ->assertSee('3') // total active users: actor + 2
-        ->assertSee('All-time account deletions');
-});
+        Livewire::actingAs($actor)
+            ->test(LoginsWidget::class)
+            ->assertSee('3')
+            ->assertSee('All-time account deletions');
+    });
 
-test('user stats widget reflects daily active users from login stats', function () {
-    $user = User::factory()->create(['timezone' => 'UTC']);
+    test('reflects daily active users from login stats', function () {
+        $user = User::factory()->createOne(['timezone' => 'UTC']);
 
-    LoginStat::increase(5);
+        LoginStat::increase(5);
 
-    Livewire::actingAs($user)
-        ->test(LoginsWidget::class)
-        ->assertSee('Daily Active Users')
-        ->assertSee('5');
+        Livewire::actingAs($user)
+            ->test(LoginsWidget::class)
+            ->assertSee('Daily Active Users')
+            ->assertSee('5');
+    });
 });

--- a/tests/Feature/NotificationBellTest.php
+++ b/tests/Feature/NotificationBellTest.php
@@ -1,121 +1,122 @@
 <?php
 
 use App\Livewire\Notifications\Bell;
-use App\Livewire\Notifications\ShowAll;
 use App\Models\Comment;
 use App\Models\Ranking;
-use App\Models\Song;
 use App\Models\User;
 use Livewire\Livewire;
 
-beforeEach(function () {
-    $this->owner = User::factory()->create();
+use function Pest\Laravel\actingAs;
 
-    $this->ranking = Ranking::factory()
-        ->has(Song::factory()->count(3))
-        ->create([
-            'user_id' => $this->owner->getKey(),
-            'is_public' => true,
-            'is_ranked' => true,
-            'comments_enabled' => true,
-        ]);
-});
-
-describe('Notification Bell Component', function () {
+describe('notification bell component', function () {
     test('renders for authenticated users', function () {
-        Livewire::actingAs($this->owner)
+        Livewire::actingAs(User::factory()->createOne())
             ->test(Bell::class)
             ->assertOk();
     });
 
     test('shows zero unread count when no notifications exist', function () {
-        Livewire::actingAs($this->owner)
+        Livewire::actingAs(User::factory()->createOne())
             ->test(Bell::class)
             ->assertSet('unreadCount', 0);
     });
 
     test('shows correct unread count', function () {
-        $commenter = User::factory()->create();
+        $ranking = commentableRanking();
+        $commenter = User::factory()->createOne();
 
-        createComment($commenter, $this->ranking, 'First comment');
-        createComment($commenter, $this->ranking, 'Second comment');
+        createComment($commenter, $ranking, 'First comment');
+        createComment($commenter, $ranking, 'Second comment');
 
-        Livewire::actingAs($this->owner)
+        Livewire::actingAs($ranking->user)
             ->test(Bell::class)
             ->assertSet('unreadCount', 2);
     });
 
     test('opening bell marks all notifications as read', function () {
-        $commenter = User::factory()->create();
+        $ranking = commentableRanking();
+        $owner = $ranking->user;
+        $commenter = User::factory()->createOne();
 
-        createComment($commenter, $this->ranking, 'Comment 1');
-        createComment($commenter, $this->ranking, 'Comment 2');
-        createComment($commenter, $this->ranking, 'Comment 3');
+        createComment($commenter, $ranking, 'Comment 1');
+        createComment($commenter, $ranking, 'Comment 2');
+        createComment($commenter, $ranking, 'Comment 3');
 
-        Livewire::actingAs($this->owner)
+        Livewire::actingAs($owner)
             ->test(Bell::class)
             ->assertSet('unreadCount', 3)
             ->call('open')
             ->assertSet('unreadCount', 0);
 
-        expect($this->owner->unreadNotifications()->count())->toBe(0);
-        expect($this->owner->notifications()->count())->toBe(3);
+        expect($owner->unreadNotifications()->count())->toBe(0);
+        expect($owner->notifications()->count())->toBe(3);
     });
 });
 
-describe('Notifications ShowAll Page', function () {
+describe('notifications page', function () {
     test('authenticated user can view notifications page', function () {
-        $this->actingAs($this->owner)
+        actingAs(User::factory()->createOne())
             ->get(route('notifications'))
             ->assertOk();
     });
 });
 
-describe('Comment Notification Dispatch', function () {
+describe('comment notification dispatch', function () {
     test('notification is created when someone comments on a ranking', function () {
-        $commenter = User::factory()->create();
+        $ranking = commentableRanking();
+        $owner = $ranking->user;
+        $commenter = User::factory()->createOne();
 
-        createComment($commenter, $this->ranking, 'This is a test comment');
+        createComment($commenter, $ranking, 'This is a test comment');
 
-        expect($this->owner->notifications()->count())->toBe(1);
+        expect($owner->notifications()->count())->toBe(1);
 
-        $notification = $this->owner->notifications()->first();
+        $notification = $owner->notifications()->first();
 
         expect($notification->user_name)->toBe($commenter->name);
-        expect($notification->entity['name'])->toBe($this->ranking->name);
-        expect($notification->entity['id'])->toBe($this->ranking->getKey());
+        expect($notification->entity['name'])->toBe($ranking->name);
+        expect($notification->entity['id'])->toBe($ranking->getKey());
     });
 
     test('notification is not created when owner comments on their own ranking', function () {
-        createComment($this->owner, $this->ranking, 'My own comment');
+        $ranking = commentableRanking();
 
-        expect($this->owner->notifications()->count())->toBe(0);
+        createComment($ranking->user, $ranking, 'My own comment');
+
+        expect($ranking->user->notifications()->count())->toBe(0);
     });
 
     test('unread notification is removed when comment is deleted', function () {
-        $commenter = User::factory()->create();
+        $ranking = commentableRanking();
+        $commenter = User::factory()->createOne();
 
-        $comment = createComment($commenter, $this->ranking);
+        $comment = createComment($commenter, $ranking);
 
-        expect($this->owner->notifications()->count())->toBe(1);
+        expect($ranking->user->notifications()->count())->toBe(1);
 
         $comment->delete();
 
-        expect($this->owner->notifications()->count())->toBe(0);
+        expect($ranking->user->notifications()->count())->toBe(0);
     });
 
     test('read notification is kept when comment is deleted', function () {
-        $commenter = User::factory()->create();
+        $ranking = commentableRanking();
+        $commenter = User::factory()->createOne();
 
-        $comment = createComment($commenter, $this->ranking);
+        $comment = createComment($commenter, $ranking);
 
-        $this->owner->notifications()->first()->markAsRead();
+        $ranking->user->notifications()->first()->markAsRead();
 
         $comment->delete();
 
-        expect($this->owner->notifications()->count())->toBe(1);
+        expect($ranking->user->notifications()->count())->toBe(1);
     });
 });
+
+function commentableRanking(): Ranking
+{
+    return publicCompletedRanking(['comments_enabled' => true]);
+}
 
 function createComment(User $commenter, Ranking $ranking, string $text = 'Great ranking!'): Comment
 {

--- a/tests/Feature/ProfilePageTest.php
+++ b/tests/Feature/ProfilePageTest.php
@@ -3,62 +3,61 @@
 use App\Models\Ranking;
 use App\Models\User;
 
-test('profile loaded user rankings', function () {
-    $user = User::factory()->create();
+use function Pest\Laravel\actingAs;
 
-    $ranking = Ranking::factory()->create([
-        'user_id' => $user->getKey(),
-        'is_public' => true,
-        'is_ranked' => true,
-        'completed_at' => now(),
-    ]);
+describe('profile page', function () {
+    test('shows the users completed public rankings', function () {
+        $user = User::factory()->createOne();
 
-    $this->actingAs($user)
-        ->get(route('profile', ['id' => $user->spotify_id]))
-        ->assertOk()
-        ->assertSee($user->rankings->first()->name);
-});
+        $ranking = publicCompletedRanking(['user_id' => $user->getKey()]);
 
-test('profile shows unfinished rankings to profile owner only', function () {
-    $user = User::factory()->create();
-    $otherUser = User::factory()->create();
+        actingAs($user)
+            ->get(route('profile', ['id' => $user->spotify_id]))
+            ->assertOk()
+            ->assertSee($ranking->name);
+    });
 
-    $ranking = Ranking::factory()->create([
-        'user_id' => $user->getKey(),
-        'is_public' => true,
-        'is_ranked' => false,
-        'completed_at' => null,
-    ]);
+    test('shows unfinished rankings to the profile owner only', function () {
+        $user = User::factory()->createOne();
+        $otherUser = User::factory()->createOne();
 
-    $this->actingAs($user)
-        ->get(route('profile', ['id' => $user->spotify_id]))
-        ->assertOk()
-        ->assertSee($user->rankings->first()->name);
+        $ranking = Ranking::factory()->create([
+            'user_id' => $user->getKey(),
+            'is_public' => true,
+            'is_ranked' => false,
+            'completed_at' => null,
+        ]);
 
-    $this->actingAs($otherUser)
-        ->get(route('profile', ['id' => $user->spotify_id]))
-        ->assertOk()
-        ->assertDontSee($user->rankings->first()->name);
-});
+        actingAs($user)
+            ->get(route('profile', ['id' => $user->spotify_id]))
+            ->assertOk()
+            ->assertSee($ranking->name);
 
-test('profile shows private rankings to profile owner only', function () {
-    $user = User::factory()->create();
-    $otherUser = User::factory()->create();
+        actingAs($otherUser)
+            ->get(route('profile', ['id' => $user->spotify_id]))
+            ->assertOk()
+            ->assertDontSee($ranking->name);
+    });
 
-    $ranking = Ranking::factory()->create([
-        'user_id' => $user->getKey(),
-        'is_public' => false,
-        'is_ranked' => true,
-        'completed_at' => now(),
-    ]);
+    test('shows private rankings to the profile owner only', function () {
+        $user = User::factory()->createOne();
+        $otherUser = User::factory()->createOne();
 
-    $this->actingAs($user)
-        ->get(route('profile', ['id' => $user->spotify_id]))
-        ->assertOk()
-        ->assertSee($user->rankings->first()->name);
+        $ranking = Ranking::factory()->create([
+            'user_id' => $user->getKey(),
+            'is_public' => false,
+            'is_ranked' => true,
+            'completed_at' => now(),
+        ]);
 
-    $this->actingAs($otherUser)
-        ->get(route('profile', ['id' => $user->spotify_id]))
-        ->assertOk()
-        ->assertDontSee($user->rankings->first()->name);
+        actingAs($user)
+            ->get(route('profile', ['id' => $user->spotify_id]))
+            ->assertOk()
+            ->assertSee($ranking->name);
+
+        actingAs($otherUser)
+            ->get(route('profile', ['id' => $user->spotify_id]))
+            ->assertOk()
+            ->assertDontSee($ranking->name);
+    });
 });

--- a/tests/Feature/Rankings/RankingAlgorithmTest.php
+++ b/tests/Feature/Rankings/RankingAlgorithmTest.php
@@ -11,12 +11,156 @@ use Livewire\Livewire;
 
 beforeEach(function () {
     Artist::factory()->create();
-    User::factory()->create();
+    User::factory()->createOne();
 });
 
-test('ranks songs in the expected order based on user selections', function () {
-    $user = User::factory()->create();
+describe('ranking algorithm', function () {
+    test('ranks songs in the expected order based on user selections', function () {
+        $user = User::factory()->createOne();
+        $expectedSongTitles = expectedSongTitles(5);
+        $ranking = algorithmRanking($user, 'Algorithm Test Ranking', $expectedSongTitles);
 
+        $sortingState = RankingSortingState::create([
+            'ranking_id' => $ranking->getKey(),
+        ]);
+
+        $component = Livewire::actingAs($user)
+            ->test(SongRankProcess::class, [
+                'ranking' => $ranking,
+                'sortingState' => $sortingState,
+            ]);
+
+        simulateRankingComparisons($component, maxComparisons: 50);
+
+        $ranking->refresh();
+        $sortingState->refresh();
+
+        expect($ranking->is_ranked)->toBeTrue();
+        expect($ranking->completed_at)->not->toBeNull();
+        expect($sortingState->sorting_state)->toBeNull();
+
+        foreach ($ranking->songs()->get() as $song) {
+            expect($song->rank)->toBeGreaterThan(0);
+            expect($song->title)->toBe($expectedSongTitles[$song->rank]);
+        }
+    });
+
+    test('completes ranking with minimum of 2 songs', function () {
+        $user = User::factory()->createOne();
+        $expectedSongTitles = expectedSongTitles(2);
+        $ranking = algorithmRanking($user, 'Two Song Ranking', $expectedSongTitles);
+
+        $sortingState = RankingSortingState::create([
+            'ranking_id' => $ranking->getKey(),
+        ]);
+
+        $component = Livewire::actingAs($user)
+            ->test(SongRankProcess::class, [
+                'ranking' => $ranking,
+                'sortingState' => $sortingState,
+            ]);
+
+        simulateRankingComparisons($component, maxComparisons: 5);
+
+        $ranking->refresh();
+
+        expect($ranking->is_ranked)->toBeTrue();
+        expect($ranking->songs()->count())->toBe(2);
+
+        foreach ($ranking->songs()->get() as $song) {
+            expect($song->title)->toBe($expectedSongTitles[$song->rank]);
+        }
+    });
+
+    test('completes ranking with 10 songs', function () {
+        $user = User::factory()->createOne();
+        $expectedSongTitles = expectedSongTitles(10);
+        $ranking = algorithmRanking($user, 'Ten Song Ranking', $expectedSongTitles);
+
+        $sortingState = RankingSortingState::create([
+            'ranking_id' => $ranking->getKey(),
+        ]);
+
+        $component = Livewire::actingAs($user)
+            ->test(SongRankProcess::class, [
+                'ranking' => $ranking,
+                'sortingState' => $sortingState,
+            ]);
+
+        simulateRankingComparisons($component, maxComparisons: 100);
+
+        $ranking->refresh();
+
+        expect($ranking->is_ranked)->toBeTrue();
+        expect($ranking->songs()->count())->toBe(10);
+
+        foreach ($ranking->songs()->get() as $song) {
+            expect($song->title)->toBe($expectedSongTitles[$song->rank]);
+        }
+    });
+
+    test('can resume ranking progress after interruption', function () {
+        $user = User::factory()->createOne();
+        $expectedSongTitles = expectedSongTitles(5);
+        $ranking = algorithmRanking($user, 'Resumable Ranking', $expectedSongTitles);
+
+        $sortingState = RankingSortingState::create([
+            'ranking_id' => $ranking->getKey(),
+            'sorting_state' => null,
+            'aprox_comparisons' => 0,
+            'completed_comparisons' => 0,
+        ]);
+
+        $firstSession = Livewire::actingAs($user)
+            ->test(SongRankProcess::class, [
+                'ranking' => $ranking,
+                'sortingState' => $sortingState,
+            ]);
+
+        simulateRankingComparisons($firstSession, maxComparisons: 3);
+
+        $sortingState->refresh();
+
+        expect($sortingState->completed_comparisons)->toBeGreaterThan(0);
+        expect($ranking->fresh()->is_ranked)->toBeFalse();
+
+        $secondSession = Livewire::actingAs($user)
+            ->test(SongRankProcess::class, [
+                'ranking' => $ranking->fresh(),
+                'sortingState' => $sortingState->fresh(),
+            ]);
+
+        simulateRankingComparisons($secondSession, maxComparisons: 50);
+
+        $ranking->refresh();
+
+        expect($ranking->is_ranked)->toBeTrue();
+
+        foreach ($ranking->songs()->get() as $song) {
+            expect($song->title)->toBe($expectedSongTitles[$song->rank]);
+        }
+    });
+});
+
+/**
+ * Build the expected rank => title map for an algorithm test.
+ *
+ * @return array<int, string>
+ */
+function expectedSongTitles(int $count): array
+{
+    return collect(range(1, $count))
+        ->mapWithKeys(fn (int $i) => [$i => "Should be number {$i}"])
+        ->all();
+}
+
+/**
+ * Create an unranked artist ranking with one song per expected title.
+ *
+ * @param  array<int, string>  $expectedSongTitles
+ */
+function algorithmRanking(User $user, string $name, array $expectedSongTitles): Ranking
+{
     $artist = Artist::factory()->create([
         'artist_name' => 'Test Artist',
         'is_podcast' => false,
@@ -25,18 +169,10 @@ test('ranks songs in the expected order based on user selections', function () {
     $ranking = Ranking::create([
         'user_id' => $user->getKey(),
         'artist_id' => $artist->getKey(),
-        'name' => 'Algorithm Test Ranking',
+        'name' => $name,
         'is_ranked' => false,
         'is_public' => true,
     ]);
-
-    $expectedSongTitles = [
-        1 => 'Should be number 1',
-        2 => 'Should be number 2',
-        3 => 'Should be number 3',
-        4 => 'Should be number 4',
-        5 => 'Should be number 5',
-    ];
 
     foreach ($expectedSongTitles as $title) {
         Song::factory()->create([
@@ -47,208 +183,8 @@ test('ranks songs in the expected order based on user selections', function () {
         ]);
     }
 
-    $sortingState = RankingSortingState::create([
-        'ranking_id' => $ranking->getKey(),
-    ]);
-
-    $component = Livewire::actingAs($user)
-        ->test(SongRankProcess::class, [
-            'ranking' => $ranking,
-            'sortingState' => $sortingState,
-        ]);
-
-    simulateRankingComparisons($component, maxComparisons: 50);
-
-    $ranking->refresh();
-    $sortingState->refresh();
-
-    expect($ranking->is_ranked)->toBeTrue();
-    expect($ranking->completed_at)->not->toBeNull();
-    expect($sortingState->sorting_state)->toBeNull();
-
-    foreach ($ranking->songs()->get() as $song) {
-        expect($song->rank)->toBeGreaterThan(0);
-        expect($song->title)->toBe($expectedSongTitles[$song->rank]);
-    }
-});
-
-test('completes ranking with minimum of 2 songs', function () {
-    $user = User::factory()->create();
-
-    $artist = Artist::factory()->create([
-        'artist_name' => 'Test Artist',
-        'is_podcast' => false,
-    ]);
-
-    $ranking = Ranking::create([
-        'user_id' => $user->getKey(),
-        'artist_id' => $artist->getKey(),
-        'name' => 'Two Song Ranking',
-        'is_ranked' => false,
-        'is_public' => true,
-    ]);
-
-    $expectedSongTitles = [
-        1 => 'Should be number 1',
-        2 => 'Should be number 2',
-    ];
-
-    foreach ($expectedSongTitles as $title) {
-        Song::factory()->create([
-            'ranking_id' => $ranking->getKey(),
-            'artist_id' => $artist->getKey(),
-            'title' => $title,
-            'rank' => 0,
-        ]);
-    }
-
-    $sortingState = RankingSortingState::create([
-        'ranking_id' => $ranking->getKey(),
-        'sorting_state' => null,
-        'aprox_comparisons' => 0,
-        'completed_comparisons' => 0,
-    ]);
-
-    $component = Livewire::actingAs($user)
-        ->test(SongRankProcess::class, [
-            'ranking' => $ranking,
-            'sortingState' => $sortingState,
-        ]);
-
-    simulateRankingComparisons($component, maxComparisons: 5);
-
-    $ranking->refresh();
-
-    expect($ranking->is_ranked)->toBeTrue();
-    expect($ranking->songs()->count())->toBe(2);
-
-    foreach ($ranking->songs()->get() as $song) {
-        expect($song->title)->toBe($expectedSongTitles[$song->rank]);
-    }
-});
-
-test('completes ranking with 10 songs', function () {
-    $user = User::factory()->create();
-
-    $artist = Artist::factory()->create([
-        'artist_name' => 'Test Artist',
-        'is_podcast' => false,
-    ]);
-
-    $ranking = Ranking::create([
-        'user_id' => $user->getKey(),
-        'artist_id' => $artist->getKey(),
-        'name' => 'Ten Song Ranking',
-        'is_ranked' => false,
-        'is_public' => true,
-    ]);
-
-    $expectedSongTitles = collect(range(1, 10))
-        ->mapWithKeys(fn ($i) => [$i => "Should be number {$i}"])
-        ->toArray();
-
-    foreach ($expectedSongTitles as $title) {
-        Song::factory()->create([
-            'ranking_id' => $ranking->getKey(),
-            'artist_id' => $artist->getKey(),
-            'title' => $title,
-            'rank' => 0,
-        ]);
-    }
-
-    $sortingState = RankingSortingState::create([
-        'ranking_id' => $ranking->getKey(),
-    ]);
-
-    $component = Livewire::actingAs($user)
-        ->test(SongRankProcess::class, [
-            'ranking' => $ranking,
-            'sortingState' => $sortingState,
-        ]);
-
-    simulateRankingComparisons($component, maxComparisons: 100);
-
-    $ranking->refresh();
-
-    expect($ranking->is_ranked)->toBeTrue();
-    expect($ranking->songs()->count())->toBe(10);
-
-    foreach ($ranking->songs()->get() as $song) {
-        expect($song->title)->toBe($expectedSongTitles[$song->rank]);
-    }
-});
-
-test('can resume ranking progress after interruption', function () {
-    $user = User::factory()->create();
-
-    $artist = Artist::factory()->create([
-        'artist_name' => 'Test Artist',
-        'is_podcast' => false,
-    ]);
-
-    $ranking = Ranking::create([
-        'user_id' => $user->getKey(),
-        'artist_id' => $artist->getKey(),
-        'name' => 'Resumable Ranking',
-        'is_ranked' => false,
-        'is_public' => true,
-    ]);
-
-    $expectedSongTitles = [
-        1 => 'Should be number 1',
-        2 => 'Should be number 2',
-        3 => 'Should be number 3',
-        4 => 'Should be number 4',
-        5 => 'Should be number 5',
-    ];
-
-    foreach ($expectedSongTitles as $title) {
-        Song::factory()->create([
-            'ranking_id' => $ranking->getKey(),
-            'artist_id' => $artist->getKey(),
-            'title' => $title,
-            'rank' => 0,
-        ]);
-    }
-
-    $sortingState = RankingSortingState::create([
-        'ranking_id' => $ranking->getKey(),
-        'sorting_state' => null,
-        'aprox_comparisons' => 0,
-        'completed_comparisons' => 0,
-    ]);
-
-    // First session - make 3 comparisons then "leave"
-    $firstSession = Livewire::actingAs($user)
-        ->test(SongRankProcess::class, [
-            'ranking' => $ranking,
-            'sortingState' => $sortingState,
-        ]);
-
-    simulateRankingComparisons($firstSession, maxComparisons: 3);
-
-    $sortingState->refresh();
-
-    expect($sortingState->completed_comparisons)->toBeGreaterThan(0);
-    expect($ranking->fresh()->is_ranked)->toBeFalse();
-
-    // Second session - resume and complete
-    $secondSession = Livewire::actingAs($user)
-        ->test(SongRankProcess::class, [
-            'ranking' => $ranking->fresh(),
-            'sortingState' => $sortingState->fresh(),
-        ]);
-
-    simulateRankingComparisons($secondSession, maxComparisons: 50);
-
-    $ranking->refresh();
-
-    expect($ranking->is_ranked)->toBeTrue();
-
-    foreach ($ranking->songs()->get() as $song) {
-        expect($song->title)->toBe($expectedSongTitles[$song->rank]);
-    }
-});
+    return $ranking;
+}
 
 /**
  * Simulate user selections during the ranking process.

--- a/tests/Feature/Rankings/RankingCommentsTest.php
+++ b/tests/Feature/Rankings/RankingCommentsTest.php
@@ -1,47 +1,60 @@
 <?php
 
-use App\Models\Artist;
-use App\Models\Ranking;
-use App\Models\Song;
 use App\Models\User;
 
-beforeEach(function () {
-    Artist::factory()->create();
-    User::factory()->create();
-});
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
 
-test('displays comments component when comments are enabled', function () {
-    $user = User::factory()->create();
+describe('ranking comments', function () {
+    test('displays comments component when comments are enabled', function () {
+        $user = User::factory()->createOne();
 
-    $ranking = Ranking::factory()
-        ->has(Song::factory()->count(5))
-        ->create([
+        $ranking = publicCompletedRanking([
             'user_id' => $user->getKey(),
-            'is_public' => true,
             'comments_enabled' => true,
-            'is_ranked' => true,
         ]);
 
-    $this->actingAs($user)
-        ->get(route('ranking', ['id' => $ranking->getKey()]))
-        ->assertOk()
-        ->assertSeeLivewire('comments');
+        actingAs($user)
+            ->get(route('ranking', ['id' => $ranking->getKey()]))
+            ->assertOk()
+            ->assertSeeLivewire('comments');
+    });
+
+    test('hides comments component when comments are disabled', function () {
+        $user = User::factory()->createOne();
+
+        $ranking = publicCompletedRanking([
+            'user_id' => $user->getKey(),
+            'comments_enabled' => false,
+        ]);
+
+        actingAs($user)
+            ->get(route('ranking', ['id' => $ranking->getKey()]))
+            ->assertOk()
+            ->assertDontSeeLivewire('comments');
+    });
 });
 
-test('hides comments component when comments are disabled', function () {
-    $user = User::factory()->create();
-
-    $ranking = Ranking::factory()
-        ->has(Song::factory()->count(5))
-        ->create([
-            'user_id' => $user->getKey(),
-            'is_public' => true,
-            'comments_enabled' => false,
-            'is_ranked' => true,
+describe('ranking comment replies', function () {
+    test('allows replies when comment replies are enabled', function () {
+        $ranking = publicCompletedRanking([
+            'comments_enabled' => true,
+            'comments_replies_enabled' => true,
         ]);
 
-    $this->actingAs($user)
-        ->get(route('ranking', ['id' => $ranking->getKey()]))
-        ->assertOk()
-        ->assertDontSeeLivewire('comments');
+        get(route('ranking', ['id' => $ranking->getKey()]))
+            ->assertOk()
+            ->assertSee('&quot;showReplies&quot;:true', false);
+    });
+
+    test('disables replies when comment replies are disabled', function () {
+        $ranking = publicCompletedRanking([
+            'comments_enabled' => true,
+            'comments_replies_enabled' => false,
+        ]);
+
+        get(route('ranking', ['id' => $ranking->getKey()]))
+            ->assertOk()
+            ->assertSee('&quot;showReplies&quot;:false', false);
+    });
 });

--- a/tests/Feature/Rankings/RankingCreationTest.php
+++ b/tests/Feature/Rankings/RankingCreationTest.php
@@ -9,233 +9,241 @@ use App\Models\Show;
 use App\Models\User;
 use Livewire\Livewire;
 
+use function Pest\Laravel\get;
+
 beforeEach(function () {
     Artist::factory()->create();
-    User::factory()->create();
+    User::factory()->createOne();
 });
 
-test('unauthenticated user cannot access ranking setup', function () {
-    $this->get(route('dashboard'))->assertRedirect(route('welcome'));
+describe('ranking setup access', function () {
+    test('unauthenticated user cannot access ranking setup', function () {
+        get(route('dashboard'))->assertRedirect(route('welcome'));
+    });
 });
 
-test('can create a ranking for an artist', function () {
-    expect(Artist::where('artist_id', 'test-artist-id')->exists())->toBeFalse();
-    expect(Ranking::where('name', 'Local Natives List')->exists())->toBeFalse();
+describe('creating rankings', function () {
+    test('can create a ranking for an artist', function () {
+        expect(Artist::where('artist_id', 'test-artist-id')->exists())->toBeFalse();
+        expect(Ranking::where('name', 'Local Natives List')->exists())->toBeFalse();
 
-    Livewire::actingAs(User::first())
-        ->test(SongRankSetup::class)
-        ->set('selectedArtist', [
-            'id' => 'test-artist-id',
-            'name' => 'Local Natives',
-            'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=testing',
-        ])
-        ->set('selectedTracks', collect([
-            [
-                'id' => 'ceilings-id',
-                'name' => 'Ceilings',
-                'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=ceilings',
-                'uuid' => str()->uuid()->toString(),
-            ],
-            [
-                'id' => 'sun-hands-id',
-                'name' => 'Sun Hands',
-                'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=sun_hands',
-                'uuid' => str()->uuid()->toString(),
-            ],
-            [
-                'id' => 'featherweight-id',
-                'name' => 'Featherweight',
-                'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=featherweight',
-                'uuid' => str()->uuid()->toString(),
-            ],
-        ]))
-        ->set('type', RankingType::ARTIST)
-        ->set('form.name', 'Local Natives List')
-        ->set('form.is_public', true)
-        ->call('beginRanking')
-        ->assertHasNoErrors();
+        Livewire::actingAs(User::factory()->createOne())
+            ->test(SongRankSetup::class)
+            ->set('selectedArtist', [
+                'id' => 'test-artist-id',
+                'name' => 'Local Natives',
+                'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=testing',
+            ])
+            ->set('selectedTracks', collect([
+                [
+                    'id' => 'ceilings-id',
+                    'name' => 'Ceilings',
+                    'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=ceilings',
+                    'uuid' => str()->uuid()->toString(),
+                ],
+                [
+                    'id' => 'sun-hands-id',
+                    'name' => 'Sun Hands',
+                    'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=sun_hands',
+                    'uuid' => str()->uuid()->toString(),
+                ],
+                [
+                    'id' => 'featherweight-id',
+                    'name' => 'Featherweight',
+                    'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=featherweight',
+                    'uuid' => str()->uuid()->toString(),
+                ],
+            ]))
+            ->set('type', RankingType::ARTIST)
+            ->set('form.name', 'Local Natives List')
+            ->set('form.is_public', true)
+            ->call('beginRanking')
+            ->assertHasNoErrors();
 
-    $artist = Artist::where('artist_id', 'test-artist-id')->first();
-    $ranking = Ranking::where('name', 'Local Natives List')->first();
+        $artist = Artist::where('artist_id', 'test-artist-id')->first();
+        $ranking = Ranking::where('name', 'Local Natives List')->first();
 
-    expect($artist)->not->toBeNull();
-    expect($artist->artist_name)->toBe('Local Natives');
+        expect($artist)->not->toBeNull();
+        expect($artist->artist_name)->toBe('Local Natives');
 
-    expect($ranking)->not->toBeNull();
-    expect($ranking->songs()->count())->toBe(3);
+        expect($ranking)->not->toBeNull();
+        expect($ranking->songs()->count())->toBe(3);
+    });
+
+    test('can create a ranking for a playlist', function () {
+        expect(Playlist::where('playlist_id', 'test-playlist-id')->exists())->toBeFalse();
+        expect(Ranking::where('name', 'Test Playlist List')->exists())->toBeFalse();
+
+        Livewire::actingAs(User::factory()->createOne())
+            ->test(SongRankSetup::class)
+            ->set('selectedPlaylist', [
+                'id' => 'test-playlist-id',
+                'name' => 'Playlist Name',
+                'description' => 'Playlist Description',
+                'creator' => [
+                    'display_name' => 'test-creator-name',
+                    'id' => 'test-creator-id',
+                ],
+                'cover' => 'playlist-cover',
+                'track_count' => 3,
+            ])
+            ->set('selectedTracks', collect([
+                [
+                    'id' => 'ceilings-id',
+                    'name' => 'Ceilings',
+                    'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=ceilings',
+                    'uuid' => str()->uuid()->toString(),
+                    'artist_id' => 'local-natives-id',
+                    'artist_name' => 'Local Natives',
+                    'is_podcast' => false,
+                ],
+                [
+                    'id' => 'sun-hands-id',
+                    'name' => 'Sun Hands',
+                    'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=sun_hands',
+                    'uuid' => str()->uuid()->toString(),
+                    'artist_id' => 'local-natives-id',
+                    'artist_name' => 'Local Natives',
+                    'is_podcast' => false,
+                ],
+                [
+                    'id' => 'featherweight-id',
+                    'name' => 'Featherweight',
+                    'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=featherweight',
+                    'uuid' => str()->uuid()->toString(),
+                    'artist_id' => 'local-natives-id',
+                    'artist_name' => 'Local Natives',
+                    'is_podcast' => false,
+                ],
+            ]))
+            ->set('type', RankingType::PLAYLIST)
+            ->set('form.name', 'Test Playlist List')
+            ->set('form.is_public', true)
+            ->call('beginRanking')
+            ->assertHasNoErrors();
+
+        $playlist = Playlist::where('playlist_id', 'test-playlist-id')->first();
+        $ranking = Ranking::where('name', 'Test Playlist List')->first();
+
+        expect($playlist)->not->toBeNull();
+        expect($playlist->creator_id)->toBe('test-creator-id');
+        expect($playlist->creator_name)->toBe('test-creator-name');
+        expect($playlist->name)->toBe('Playlist Name');
+        expect($playlist->description)->toBe('Playlist Description');
+        expect($playlist->cover)->toBe('playlist-cover');
+        expect($playlist->track_count)->toBe(3);
+
+        expect($ranking)->not->toBeNull();
+        expect($ranking->songs()->count())->toBe(3);
+    });
+
+    test('can create a ranking for a show', function () {
+        expect(Show::where('show_id', 'test-show-id')->exists())->toBeFalse();
+        expect(Ranking::where('name', 'Test Show List')->exists())->toBeFalse();
+
+        Livewire::actingAs(User::factory()->createOne())
+            ->test(SongRankSetup::class)
+            ->set('selectedShow', [
+                'id' => 'test-show-id',
+                'name' => 'Test Show',
+                'publisher' => 'Test Publisher',
+                'publisher_image' => 'https://api.dicebear.com/7.x/initials/svg?seed=publisher',
+                'description' => 'A test show',
+                'cover' => 'show-cover',
+                'episode_count' => 3,
+                'data' => [],
+            ])
+            ->set('selectedTracks', collect([
+                [
+                    'id' => 'episode-1-id',
+                    'name' => 'Episode 1',
+                    'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=ep1',
+                    'uuid' => str()->uuid()->toString(),
+                ],
+                [
+                    'id' => 'episode-2-id',
+                    'name' => 'Episode 2',
+                    'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=ep2',
+                    'uuid' => str()->uuid()->toString(),
+                ],
+                [
+                    'id' => 'episode-3-id',
+                    'name' => 'Episode 3',
+                    'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=ep3',
+                    'uuid' => str()->uuid()->toString(),
+                ],
+            ]))
+            ->set('type', RankingType::SHOW)
+            ->set('form.name', 'Test Show List')
+            ->set('form.is_public', true)
+            ->call('beginRanking')
+            ->assertHasNoErrors();
+
+        $show = Show::where('show_id', 'test-show-id')->first();
+        $ranking = Ranking::where('name', 'Test Show List')->first();
+
+        expect($show)->not->toBeNull();
+        expect($show->name)->toBe('Test Show');
+        expect($show->publisher)->toBe('Test Publisher');
+
+        expect($ranking)->not->toBeNull();
+        expect($ranking->songs()->count())->toBe(3);
+    });
 });
 
-test('can create a ranking for a playlist', function () {
-    expect(Playlist::where('playlist_id', 'test-playlist-id')->exists())->toBeFalse();
-    expect(Ranking::where('name', 'Test Playlist List')->exists())->toBeFalse();
+describe('ranking setup searching', function () {
+    test('cannot search for an artist with an empty search term', function () {
+        Livewire::actingAs(User::factory()->createOne())
+            ->test(SongRankSetup::class)
+            ->set('searchTerm', '')
+            ->call('searchArtist')
+            ->assertSet('searchedArtists', null)
+            ->assertSet('selectedTracks', null);
+    });
 
-    Livewire::actingAs(User::first())
-        ->test(SongRankSetup::class)
-        ->set('selectedPlaylist', [
-            'id' => 'test-playlist-id',
-            'name' => 'Playlist Name',
-            'description' => 'Playlist Description',
-            'creator' => [
-                'display_name' => 'test-creator-name',
-                'id' => 'test-creator-id',
-            ],
-            'cover' => 'playlist-cover',
-            'track_count' => 3,
-        ])
-        ->set('selectedTracks', collect([
-            [
-                'id' => 'ceilings-id',
-                'name' => 'Ceilings',
-                'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=ceilings',
-                'uuid' => str()->uuid()->toString(),
-                'artist_id' => 'local-natives-id',
-                'artist_name' => 'Local Natives',
-                'is_podcast' => false,
-            ],
-            [
-                'id' => 'sun-hands-id',
-                'name' => 'Sun Hands',
-                'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=sun_hands',
-                'uuid' => str()->uuid()->toString(),
-                'artist_id' => 'local-natives-id',
-                'artist_name' => 'Local Natives',
-                'is_podcast' => false,
-            ],
-            [
-                'id' => 'featherweight-id',
-                'name' => 'Featherweight',
-                'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=featherweight',
-                'uuid' => str()->uuid()->toString(),
-                'artist_id' => 'local-natives-id',
-                'artist_name' => 'Local Natives',
-                'is_podcast' => false,
-            ],
-        ]))
-        ->set('type', RankingType::PLAYLIST)
-        ->set('form.name', 'Test Playlist List')
-        ->set('form.is_public', true)
-        ->call('beginRanking')
-        ->assertHasNoErrors();
+    test('cannot search for a playlist with an invalid URL', function () {
+        Livewire::actingAs(User::factory()->createOne())
+            ->test(SongRankSetup::class)
+            ->set('searchTerm', 'abcdxyz')
+            ->call('searchPlaylist')
+            ->assertSet('selectedPlaylist', [])
+            ->assertSet('selectedTracks', null);
+    });
 
-    $playlist = Playlist::where('playlist_id', 'test-playlist-id')->first();
-    $ranking = Ranking::where('name', 'Test Playlist List')->first();
+    test('can search for a playlist with a valid URL', function () {
+        Livewire::actingAs(User::factory()->createOne())
+            ->test(SongRankSetup::class)
+            ->set('type', RankingType::PLAYLIST)
+            ->set('searchTerm', 'https://open.spotify.com/playlist/1l9ToABW4nh8EdGfq3Qvei')
+            ->call('searchPlaylist')
+            ->assertSet('type', RankingType::PLAYLIST);
+    });
 
-    expect($playlist)->not->toBeNull();
-    expect($playlist->creator_id)->toBe('test-creator-id');
-    expect($playlist->creator_name)->toBe('test-creator-name');
-    expect($playlist->name)->toBe('Playlist Name');
-    expect($playlist->description)->toBe('Playlist Description');
-    expect($playlist->cover)->toBe('playlist-cover');
-    expect($playlist->track_count)->toBe(3);
+    test('cannot change ranking type after selecting an artist', function () {
+        Livewire::actingAs(User::factory()->createOne())
+            ->test(SongRankSetup::class)
+            ->set('selectedArtist', [
+                'id' => 'test-artist-id',
+                'name' => 'Local Natives',
+                'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=testing',
+            ])
+            ->set('selectedTracks', collect([
+                ['id' => 'track-1', 'name' => 'Track 1', 'cover' => 'cover', 'uuid' => str()->uuid()->toString()],
+                ['id' => 'track-2', 'name' => 'Track 2', 'cover' => 'cover', 'uuid' => str()->uuid()->toString()],
+            ]))
+            ->set('type', RankingType::PLAYLIST->value)
+            ->assertSet('type', RankingType::ARTIST)
+            ->assertNotSet('selectedArtist', null);
+    });
 
-    expect($ranking)->not->toBeNull();
-    expect($ranking->songs()->count())->toBe(3);
-});
-
-test('can create a ranking for a show', function () {
-    expect(Show::where('show_id', 'test-show-id')->exists())->toBeFalse();
-    expect(Ranking::where('name', 'Test Show List')->exists())->toBeFalse();
-
-    Livewire::actingAs(User::first())
-        ->test(SongRankSetup::class)
-        ->set('selectedShow', [
-            'id' => 'test-show-id',
-            'name' => 'Test Show',
-            'publisher' => 'Test Publisher',
-            'publisher_image' => 'https://api.dicebear.com/7.x/initials/svg?seed=publisher',
-            'description' => 'A test show',
-            'cover' => 'show-cover',
-            'episode_count' => 3,
-            'data' => [],
-        ])
-        ->set('selectedTracks', collect([
-            [
-                'id' => 'episode-1-id',
-                'name' => 'Episode 1',
-                'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=ep1',
-                'uuid' => str()->uuid()->toString(),
-            ],
-            [
-                'id' => 'episode-2-id',
-                'name' => 'Episode 2',
-                'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=ep2',
-                'uuid' => str()->uuid()->toString(),
-            ],
-            [
-                'id' => 'episode-3-id',
-                'name' => 'Episode 3',
-                'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=ep3',
-                'uuid' => str()->uuid()->toString(),
-            ],
-        ]))
-        ->set('type', RankingType::SHOW)
-        ->set('form.name', 'Test Show List')
-        ->set('form.is_public', true)
-        ->call('beginRanking')
-        ->assertHasNoErrors();
-
-    $show = Show::where('show_id', 'test-show-id')->first();
-    $ranking = Ranking::where('name', 'Test Show List')->first();
-
-    expect($show)->not->toBeNull();
-    expect($show->name)->toBe('Test Show');
-    expect($show->publisher)->toBe('Test Publisher');
-
-    expect($ranking)->not->toBeNull();
-    expect($ranking->songs()->count())->toBe(3);
-});
-
-test('cannot search for an artist with an empty search term', function () {
-    Livewire::actingAs(User::first())
-        ->test(SongRankSetup::class)
-        ->set('searchTerm', '')
-        ->call('searchArtist')
-        ->assertSet('searchedArtists', null)
-        ->assertSet('selectedTracks', null);
-});
-
-test('cannot search for a playlist with an invalid URL', function () {
-    Livewire::actingAs(User::first())
-        ->test(SongRankSetup::class)
-        ->set('searchTerm', 'abcdxyz')
-        ->call('searchPlaylist')
-        ->assertSet('selectedPlaylist', [])
-        ->assertSet('selectedTracks', null);
-});
-
-test('can search for a playlist with a valid URL', function () {
-    Livewire::actingAs(User::first())
-        ->test(SongRankSetup::class)
-        ->set('type', RankingType::PLAYLIST)
-        ->set('searchTerm', 'https://open.spotify.com/playlist/1l9ToABW4nh8EdGfq3Qvei')
-        ->call('searchPlaylist')
-        ->assertSet('type', RankingType::PLAYLIST);
-});
-
-test('cannot change ranking type after selecting an artist', function () {
-    Livewire::actingAs(User::first())
-        ->test(SongRankSetup::class)
-        ->set('selectedArtist', [
-            'id' => 'test-artist-id',
-            'name' => 'Local Natives',
-            'cover' => 'https://api.dicebear.com/7.x/initials/svg?seed=testing',
-        ])
-        ->set('selectedTracks', collect([
-            ['id' => 'track-1', 'name' => 'Track 1', 'cover' => 'cover', 'uuid' => str()->uuid()->toString()],
-            ['id' => 'track-2', 'name' => 'Track 2', 'cover' => 'cover', 'uuid' => str()->uuid()->toString()],
-        ]))
-        ->set('type', RankingType::PLAYLIST->value)
-        ->assertSet('type', RankingType::ARTIST)
-        ->assertNotSet('selectedArtist', null);
-});
-
-test('resets search results when changing type during artist search before selection', function () {
-    Livewire::actingAs(User::first())
-        ->test(SongRankSetup::class)
-        ->set('searchedArtists', collect([
-            ['id' => 'artist-1', 'name' => 'Artist 1', 'cover' => 'cover'],
-        ]))
-        ->set('type', RankingType::PLAYLIST->value)
-        ->assertSet('type', RankingType::PLAYLIST)
-        ->assertSet('searchedArtists', null);
+    test('resets search results when changing type during artist search before selection', function () {
+        Livewire::actingAs(User::factory()->createOne())
+            ->test(SongRankSetup::class)
+            ->set('searchedArtists', collect([
+                ['id' => 'artist-1', 'name' => 'Artist 1', 'cover' => 'cover'],
+            ]))
+            ->set('type', RankingType::PLAYLIST->value)
+            ->assertSet('type', RankingType::PLAYLIST)
+            ->assertSet('searchedArtists', null);
+    });
 });

--- a/tests/Feature/Rankings/RankingManagementTest.php
+++ b/tests/Feature/Rankings/RankingManagementTest.php
@@ -8,149 +8,102 @@ use App\Models\Song;
 use App\Models\User;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+
 beforeEach(function () {
     Artist::factory()->create();
-    User::factory()->create();
+    User::factory()->createOne();
 });
 
-test('owner can view the edit page', function () {
-    $user = User::factory()
-        ->has(Ranking::factory()->count(1))
-        ->create();
+describe('editing rankings', function () {
+    test('owner can view the edit page', function () {
+        $user = User::factory()
+            ->has(Ranking::factory()->count(1))
+            ->createOne();
 
-    $this->actingAs($user)
-        ->get(route('rank.edit', ['id' => $user->rankings->first()->getKey()]))
-        ->assertOk();
-});
+        actingAs($user)
+            ->get(route('rank.edit', ['id' => $user->rankings->first()->getKey()]))
+            ->assertOk();
+    });
 
-test('non-owner cannot view the edit page', function () {
-    $ranking = Ranking::factory()->create();
+    test('non-owner cannot view the edit page', function () {
+        $ranking = Ranking::factory()->create();
 
-    $this->actingAs(User::first())
-        ->get(route('rank.edit', ['id' => $ranking->getKey()]))
-        ->assertForbidden();
-});
+        actingAs(User::factory()->createOne())
+            ->get(route('rank.edit', ['id' => $ranking->getKey()]))
+            ->assertForbidden();
+    });
 
-test('owner can update name and visibility', function () {
-    $user = User::factory()->create();
+    test('owner can update name and visibility', function () {
+        $user = User::factory()->createOne();
 
-    $ranking = Ranking::factory()
-        ->has(Song::factory()->count(5))
-        ->create([
+        $ranking = Ranking::factory()->create([
             'user_id' => $user->getKey(),
             'is_public' => false,
         ]);
 
-    Livewire::actingAs($user)
-        ->test(EditRanking::class, ['id' => $ranking->getKey()])
-        ->set('form.name', 'new name')
-        ->set('form.is_public', true)
-        ->call('update')
-        ->assertHasNoErrors();
+        Livewire::actingAs($user)
+            ->test(EditRanking::class, ['id' => $ranking->getKey()])
+            ->set('form.name', 'new name')
+            ->set('form.is_public', true)
+            ->call('update')
+            ->assertHasNoErrors();
 
-    $ranking->refresh();
+        $ranking->refresh();
 
-    expect($ranking->name)->toBe('new name');
-    expect($ranking->is_public)->toBeTrue();
+        expect($ranking->name)->toBe('new name');
+        expect($ranking->is_public)->toBeTrue();
+    });
+
+    test('non-owner cannot update name and visibility', function () {
+        $user = User::factory()->createOne();
+
+        $ranking = Ranking::factory()->create(['is_public' => false]);
+
+        Livewire::actingAs($user)
+            ->test(EditRanking::class, ['id' => $ranking->getKey()])
+            ->assertForbidden();
+    });
 });
 
-test('non-owner cannot update name and visibility', function () {
-    $user = User::factory()->create();
+describe('deleting rankings', function () {
+    test('owner can delete their ranking', function () {
+        $user = User::factory()
+            ->has(Ranking::factory())
+            ->createOne();
 
-    $ranking = Ranking::factory()
-        ->has(Song::factory()->count(5))
-        ->create(['is_public' => false]);
+        $ranking = $user->rankings->first();
 
-    Livewire::actingAs($user)
-        ->test(EditRanking::class, ['id' => $ranking->getKey()])
-        ->assertForbidden();
-});
+        expect($ranking->deleted_at)->toBeNull();
+        expect(Song::where('ranking_id', $ranking->getKey())->count())->toBe(10);
 
-test('owner can delete their ranking', function () {
-    $user = User::factory()
-        ->has(Ranking::factory())
-        ->create();
+        Livewire::actingAs($user)
+            ->test(ProfileRankingCard::class, ['ranking' => $ranking])
+            ->call('destroy')
+            ->assertDispatched('rankings-updated');
 
-    $ranking = $user->rankings->first();
+        $ranking->refresh();
 
-    expect($ranking->deleted_at)->toBeNull();
-    expect(Song::where('ranking_id', $ranking->getKey())->count())->toBe(10);
+        expect($ranking->deleted_at)->not->toBeNull();
+        expect(Song::where('ranking_id', $ranking->getKey())->count())->toBe(0);
+    });
 
-    Livewire::actingAs($user)
-        ->test(ProfileRankingCard::class, ['ranking' => $ranking])
-        ->call('destroy')
-        ->assertDispatched('rankings-updated');
+    test('non-owner cannot delete another user\'s ranking', function () {
+        $owner = User::factory()
+            ->has(Ranking::factory())
+            ->createOne();
 
-    $ranking->refresh();
+        $nonOwner = User::factory()->createOne();
+        $ranking = $owner->rankings->first();
 
-    expect($ranking->deleted_at)->not->toBeNull();
-    expect(Song::where('ranking_id', $ranking->getKey())->count())->toBe(0);
-});
+        Livewire::actingAs($nonOwner)
+            ->test(ProfileRankingCard::class, ['ranking' => $ranking])
+            ->call('destroy')
+            ->assertForbidden();
 
-test('non-owner cannot delete another user\'s ranking', function () {
-    $owner = User::factory()
-        ->has(Ranking::factory())
-        ->create();
+        $ranking->refresh();
 
-    $nonOwner = User::factory()->create();
-    $ranking = $owner->rankings->first();
-
-    expect($ranking->deleted_at)->toBeNull();
-    expect(Song::where('ranking_id', $ranking->getKey())->count())->toBe(10);
-
-    Livewire::actingAs($nonOwner)
-        ->test(ProfileRankingCard::class, ['ranking' => $ranking])
-        ->call('destroy')
-        ->assertForbidden();
-
-    $ranking->refresh();
-
-    expect($ranking->deleted_at)->toBeNull();
-    expect(Song::where('ranking_id', $ranking->getKey())->count())->toBe(10);
-});
-
-test('non-owner can view a public completed ranking', function () {
-    $visitor = User::factory()->create();
-
-    $ranking = Ranking::factory()
-        ->has(Song::factory()->count(5))
-        ->create([
-            'is_public' => true,
-            'is_ranked' => true,
-        ]);
-
-    $this->actingAs($visitor)
-        ->get(route('ranking', ['id' => $ranking->getKey()]))
-        ->assertOk();
-});
-
-test('non-owner cannot view a private ranking', function () {
-    $visitor = User::factory()->create();
-
-    $ranking = Ranking::factory()
-        ->has(Song::factory()->count(5))
-        ->create([
-            'is_public' => false,
-            'is_ranked' => true,
-        ]);
-
-    $this->actingAs($visitor)
-        ->get(route('ranking', ['id' => $ranking->getKey()]))
-        ->assertStatus(404);
-});
-
-test('owner can view their own private ranking', function () {
-    $user = User::factory()->create();
-
-    $ranking = Ranking::factory()
-        ->has(Song::factory()->count(5))
-        ->create([
-            'user_id' => $user->getKey(),
-            'is_public' => false,
-            'is_ranked' => true,
-        ]);
-
-    $this->actingAs($user)
-        ->get(route('ranking', ['id' => $ranking->getKey()]))
-        ->assertOk();
+        expect($ranking->deleted_at)->toBeNull();
+        expect(Song::where('ranking_id', $ranking->getKey())->count())->toBe(10);
+    });
 });

--- a/tests/Feature/Rankings/RankingShowPageTest.php
+++ b/tests/Feature/Rankings/RankingShowPageTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use App\Models\Ranking;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+describe('ranking show page access', function () {
+    test('non-owner can view a public completed ranking', function () {
+        $visitor = User::factory()->createOne();
+
+        $ranking = publicCompletedRanking();
+
+        actingAs($visitor)
+            ->get(route('ranking', ['id' => $ranking->getKey()]))
+            ->assertOk();
+    });
+
+    test('non-owner cannot view a private ranking', function () {
+        $visitor = User::factory()->createOne();
+
+        $ranking = Ranking::factory()->create([
+            'is_public' => false,
+            'is_ranked' => true,
+        ]);
+
+        actingAs($visitor)
+            ->get(route('ranking', ['id' => $ranking->getKey()]))
+            ->assertStatus(404);
+    });
+
+    test('owner can view their own private ranking', function () {
+        $user = User::factory()->createOne();
+
+        $ranking = Ranking::factory()->create([
+            'user_id' => $user->getKey(),
+            'is_public' => false,
+            'is_ranked' => true,
+        ]);
+
+        actingAs($user)
+            ->get(route('ranking', ['id' => $ranking->getKey()]))
+            ->assertOk();
+    });
+});
+
+describe('creator banner on the show page', function () {
+    test('is shown to other users viewing the ranking', function () {
+        $owner = User::factory()->createOne(['name' => 'Ranking Creator']);
+        $visitor = User::factory()->createOne();
+
+        $ranking = publicCompletedRanking(['user_id' => $owner->getKey()]);
+
+        actingAs($visitor)
+            ->get(route('ranking', ['id' => $ranking->getKey()]))
+            ->assertOk()
+            ->assertSee('Ranked by')
+            ->assertSee('Ranking Creator');
+    });
+
+    test('is shown to guests viewing the ranking', function () {
+        $owner = User::factory()->createOne(['name' => 'Ranking Creator']);
+
+        $ranking = publicCompletedRanking(['user_id' => $owner->getKey()]);
+
+        get(route('ranking', ['id' => $ranking->getKey()]))
+            ->assertOk()
+            ->assertSee('Ranked by')
+            ->assertSee('Ranking Creator');
+    });
+
+    test('is hidden from the ranking creator', function () {
+        $owner = User::factory()->createOne();
+
+        $ranking = publicCompletedRanking(['user_id' => $owner->getKey()]);
+
+        actingAs($owner)
+            ->get(route('ranking', ['id' => $ranking->getKey()]))
+            ->assertOk()
+            ->assertDontSee('Ranked by');
+    });
+});

--- a/tests/Feature/SettingsPageTest.php
+++ b/tests/Feature/SettingsPageTest.php
@@ -8,84 +8,89 @@ use App\Notifications\DownloadDataNotification;
 use Illuminate\Support\Facades\Notification;
 use Livewire\Livewire;
 
-test('user can enable newsletter emails', function () {
-    $user = User::factory()->create();
-    $user->preferences->update(['recieve_newsletter_emails' => false]);
+use function Pest\Laravel\assertGuest;
 
-    Livewire::actingAs($user)
-        ->test(Settings::class)
-        ->call('updateSetting', 'recieve_newsletter_emails', true);
+describe('newsletter preferences', function () {
+    test('user can enable newsletter emails', function () {
+        $user = User::factory()->createOne();
+        $user->preferences->update(['recieve_newsletter_emails' => false]);
 
-    expect($user->fresh()->preferences->recieve_newsletter_emails)->toBeTrue();
+        Livewire::actingAs($user)
+            ->test(Settings::class)
+            ->call('updateSetting', 'recieve_newsletter_emails', true);
+
+        expect($user->fresh()->preferences->recieve_newsletter_emails)->toBeTrue();
+    });
+
+    test('user can disable newsletter emails', function () {
+        $user = User::factory()->createOne();
+        $user->preferences->update(['recieve_newsletter_emails' => true]);
+
+        Livewire::actingAs($user)
+            ->test(Settings::class)
+            ->call('updateSetting', 'recieve_newsletter_emails', false);
+
+        expect($user->fresh()->preferences->recieve_newsletter_emails)->toBeFalse();
+    });
 });
 
-test('user can disable newsletter emails', function () {
-    $user = User::factory()->create();
-    $user->preferences->update(['recieve_newsletter_emails' => true]);
+describe('account deletion', function () {
+    test('user receives download notification when deleting account with rankings', function () {
+        Notification::fake();
 
-    Livewire::actingAs($user)
-        ->test(Settings::class)
-        ->call('updateSetting', 'recieve_newsletter_emails', false);
+        $user = User::factory()->createOne();
+        Ranking::factory()->count(3)->create(['user_id' => $user->getKey()]);
 
-    expect($user->fresh()->preferences->recieve_newsletter_emails)->toBeFalse();
-});
+        DeleteUserJob::dispatch($user);
 
-test('user receives download notification when deleting account with rankings', function () {
-    Notification::fake();
+        Notification::assertSentTo($user, DownloadDataNotification::class);
+    });
 
-    $user = User::factory()->create();
-    Ranking::factory()->count(3)->create(['user_id' => $user->id]);
+    test('user does not receive download notification when deleting account without rankings', function () {
+        Notification::fake();
 
-    DeleteUserJob::dispatch($user);
+        $user = User::factory()->createOne();
 
-    Notification::assertSentTo($user, DownloadDataNotification::class);
-});
+        DeleteUserJob::dispatch($user);
 
-test('user does not receive download notification when deleting account without rankings', function () {
-    Notification::fake();
+        Notification::assertNotSentTo($user, DownloadDataNotification::class);
+    });
 
-    $user = User::factory()->create();
+    test('user can delete their account', function () {
+        Notification::fake();
 
-    DeleteUserJob::dispatch($user);
+        $user = User::factory()->createOne();
 
-    Notification::assertNotSentTo($user, DownloadDataNotification::class);
-});
+        Livewire::actingAs($user)
+            ->test(Settings::class)
+            ->call('destroy', $user->getKey())
+            ->assertRedirect('/');
 
-test('user can delete their account', function () {
-    Notification::fake();
+        expect(User::find($user->getKey()))->toBeNull();
+        assertGuest();
+    });
 
-    $user = User::factory()->create();
+    test('account deletion also deletes their rankings', function () {
+        Notification::fake();
 
-    Livewire::actingAs($user)
-        ->test(Settings::class)
-        ->call('destroy', $user->id)
-        ->assertRedirect('/');
+        $user = User::factory()->createOne();
+        $rankingIds = Ranking::factory()->count(3)->create(['user_id' => $user->getKey()])->pluck('id');
 
-    expect(User::find($user->id))->toBeNull();
-    $this->assertGuest();
-});
+        DeleteUserJob::dispatchSync($user);
 
-test('user account deletion also deletes their rankings', function () {
-    Notification::fake();
+        expect(User::find($user->getKey()))->toBeNull();
+        expect(Ranking::whereIn('id', $rankingIds)->count())->toBe(0);
+    });
 
-    $user = User::factory()->create();
-    $rankings = Ranking::factory()->count(3)->create(['user_id' => $user->id]);
-    $rankingIds = $rankings->pluck('id');
+    test('user cannot delete another users account', function () {
+        $user = User::factory()->createOne();
+        $otherUser = User::factory()->createOne();
 
-    DeleteUserJob::dispatchSync($user);
+        Livewire::actingAs($user)
+            ->test(Settings::class)
+            ->call('destroy', $otherUser->getKey())
+            ->assertForbidden();
 
-    expect(User::find($user->id))->toBeNull();
-    expect(Ranking::whereIn('id', $rankingIds)->count())->toBe(0);
-});
-
-test('user cannot delete another users account', function () {
-    $user = User::factory()->create();
-    $otherUser = User::factory()->create();
-
-    Livewire::actingAs($user)
-        ->test(Settings::class)
-        ->call('destroy', $otherUser->id)
-        ->assertForbidden();
-
-    expect(User::find($otherUser->id))->not->toBeNull();
+        expect(User::find($otherUser->getKey()))->not->toBeNull();
+    });
 });

--- a/tests/Feature/SupportPageTest.php
+++ b/tests/Feature/SupportPageTest.php
@@ -2,12 +2,16 @@
 
 use App\Models\ApplicationDashboard;
 
-test('support page loads successfully', function () {
-    ApplicationDashboard::create([
-        'name' => 'Song Rank',
-        'version' => '2.0',
-        'support_page' => '<p>Support Song Rank</p>',
-    ]);
+use function Pest\Laravel\get;
 
-    $this->get(route('support'))->assertOk();
+describe('support page', function () {
+    test('loads successfully', function () {
+        ApplicationDashboard::create([
+            'name' => 'Song Rank',
+            'version' => '2.0',
+            'support_page' => '<p>Support Song Rank</p>',
+        ]);
+
+        get(route('support'))->assertOk();
+    });
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,9 @@
 <?php
 
+use App\Models\Ranking;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
 /*
 |--------------------------------------------------------------------------
 | Test Case
@@ -11,24 +15,9 @@
 |
 */
 
-pest()->extend(Tests\TestCase::class)
-    ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
+pest()->extend(TestCase::class)
+    ->use(RefreshDatabase::class)
     ->in('Feature');
-
-/*
-|--------------------------------------------------------------------------
-| Expectations
-|--------------------------------------------------------------------------
-|
-| When you're writing tests, you often need to check that values meet certain conditions. The
-| "expect()" function gives you access to a set of "expectations" methods that you can use
-| to assert different things. Of course, you may extend the Expectation API at any time.
-|
-*/
-
-expect()->extend('toBeOne', function () {
-    return $this->toBe(1);
-});
 
 /*
 |--------------------------------------------------------------------------
@@ -41,7 +30,11 @@ expect()->extend('toBeOne', function () {
 |
 */
 
-function something()
+function publicCompletedRanking(array $attributes = []): Ranking
 {
-    // ..
+    return Ranking::factory()->create(array_merge([
+        'is_public' => true,
+        'is_ranked' => true,
+        'completed_at' => now(),
+    ], $attributes));
 }


### PR DESCRIPTION
This release introduces a new Leaderboards page and significantly refactors the ranking exploration experience.

Key changes include:
-   **Leaderboards:** A dedicated page (`/leaderboards`) showcasing top ranked artists, creators by ranking count, and rankings with the most songs.
-   **Explorer Page Rework:** The `/explore` page has been streamlined. It now focuses on a global search across ranking names, artists, and playlists, removing separate artist/playlist filtering sidebars. The UI has been updated for a cleaner layout.
-   **Query Builders:** Extensive query logic, previously inline or as local scopes, has been extracted into dedicated Eloquent Query Builders for better organization, reusability, and maintainability (e.g., `topArtists`, `publicRankedCount`, `mostSongs`).
-   **Authentication Standardization:** Switched direct `auth()->user()` and `auth()->id()` calls to the `Auth::user()` and `Auth::id()` facade methods across the application for consistency.
-   **IDE Helper Integration:** Added `barryvdh/laravel-ide-helper` to the development dependencies for improved IDE auto-completion and type hinting.
-   **Cache Invalidation:** Ensured the `explore:total-rankings` cache is correctly invalidated when rankings are completed, destroyed, or edited, maintaining accurate counts.
-   **Bug Fix:** Corrected an issue where `comments_replies_enabled` was incorrectly assigned the value of `comments_enabled` during playlist ranking creation.
-   **Test Conventions:** Updated `CLAUDE.md` with Pest test file structure guidelines and added `pestphp/pest-plugin-laravel` to improve testing practices.
-   **Ranking Show Page:** Added a banner on ranking show pages to display the creator of the ranking to other users and guests.
-   **UI Enhancements:** Introduced new utility CSS classes for primary colors and medal styling, used in the new Leaderboards page.