### PR TITLE
fix: Declare flowframe/laravel-trend as a direct dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "bugsnag/bugsnag-laravel": "^2.27",
         "doctrine/dbal": "^4.0",
         "filament/filament": "~5.0",
+        "flowframe/laravel-trend": "^0.5.0",
         "guzzlehttp/guzzle": "^7.8",
         "kyledoesdev/essentials": "^0.0.8",
         "laravel/framework": "^13.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0aa9d0b70f16a55346ed22ef44796221",
+    "content-hash": "56c51ba98a5c0a9779f051bc15a2672a",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -2164,6 +2164,80 @@
                 "source": "https://github.com/googleapis/php-jwt/tree/v7.1.0"
             },
             "time": "2026-06-11T17:54:14+00:00"
+        },
+        {
+            "name": "flowframe/laravel-trend",
+            "version": "v0.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Flowframe/laravel-trend.git",
+                "reference": "1b968af2c1e1d633dc4bc78131660ae6eb67e252"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Flowframe/laravel-trend/zipball/1b968af2c1e1d633dc4bc78131660ae6eb67e252",
+                "reference": "1b968af2c1e1d633dc4bc78131660ae6eb67e252",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^8.37|^9|^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.2",
+                "spatie/laravel-package-tools": "^1.4.3"
+            },
+            "require-dev": {
+                "nunomaduro/collision": "^5.3|^6.1|^8.0",
+                "orchestra/testbench": "^6.15|^7.0|^8.0|^9.0|^10.0|^11.0",
+                "pestphp/pest": "^1.18|^2.34|^3.7|^4.4",
+                "pestphp/pest-plugin-laravel": "^1.1|^2.3|^3.1|^4.1",
+                "spatie/laravel-ray": "^1.23",
+                "vimeo/psalm": "^4.8|^5.6|^6.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Trend": "Flowframe\\Trend\\TrendFacade"
+                    },
+                    "providers": [
+                        "Flowframe\\Trend\\TrendServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Flowframe\\Trend\\": "src",
+                    "Flowframe\\Trend\\Database\\Factories\\": "database/factories"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lars Klopstra",
+                    "email": "lars@flowframe.nl",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily generate model trends",
+            "homepage": "https://github.com/flowframe/laravel-trend",
+            "keywords": [
+                "Flowframe",
+                "laravel",
+                "laravel-trend"
+            ],
+            "support": {
+                "issues": "https://github.com/Flowframe/laravel-trend/issues",
+                "source": "https://github.com/Flowframe/laravel-trend/tree/v0.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/larsklopstra",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-23T15:41:48+00:00"
         },
         {
             "name": "fruitcake/php-cors",

--- a/tests/Feature/ChartWidgetsTest.php
+++ b/tests/Feature/ChartWidgetsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Filament\Widgets\CommentsCreatedWidget;
+use App\Filament\Widgets\NewUsersWidget;
+use App\Filament\Widgets\RankingsCreatedWidget;
+use App\Models\User;
+use Livewire\Livewire;
+
+describe('trend chart widgets', function () {
+    test('renders without error', function (string $widget) {
+        $user = User::factory()->createOne(['timezone' => 'UTC']);
+
+        Livewire::actingAs($user)
+            ->test($widget)
+            ->assertOk();
+    })->with([
+        NewUsersWidget::class,
+        RankingsCreatedWidget::class,
+        CommentsCreatedWidget::class,
+    ]);
+
+    test('renders with each quick filter applied', function (string $filter) {
+        $user = User::factory()->createOne(['timezone' => 'UTC']);
+
+        Livewire::actingAs($user)
+            ->test(NewUsersWidget::class)
+            ->set('filters.filter', $filter)
+            ->assertOk();
+    })->with(['all', 'day', 'week', 'month', 'year']);
+
+    test('builds a dataset for new and deleted users', function () {
+        $actor = User::factory()->createOne(['timezone' => 'UTC']);
+        User::factory()->count(2)->create();
+        User::factory()->count(1)->create()->each->delete();
+
+        Livewire::actingAs($actor)
+            ->test(NewUsersWidget::class)
+            ->assertOk()
+            ->assertSee('New Users Widget');
+    });
+});


### PR DESCRIPTION
Three Filament chart widgets import Flowframe\Trend\Trend and TrendValue directly, but the package was never declared in composer.json — it was only reaching the app transitively via spatie/filament-simple-stats.

The Laravel 13 upgrade forced simple-stats 1.1.0 -> 1.2.1, which dropped flowframe/laravel-trend from its own requirements. The package left the dependency tree entirely and the widgets started throwing `Class "Flowframe\Trend\Trend" not found` in production.

Adds flowframe/laravel-trend ^0.5.0 (v0.5.0 supports illuminate/contracts ^13.0). Verified the widgets' exact API against the installed version: Trend::model(), Trend::query(), ->between(), ->perDay(), ->count() and TrendValue->aggregate all behave as before.

The suite missed this because the chart widgets had no coverage at all, so ChartWidgetsTest is added for NewUsersWidget, RankingsCreatedWidget and CommentsCreatedWidget, covering a plain render plus every quick filter. Confirmed the test actually detects the regression: with Trend.php removed from vendor all 9 cases fail, and they pass with it present.

Tests: 119 passed (288 assertions).