### PR TITLE
fix: Resolve admin panel bugs and Filament anti-patterns

### DIFF
--- a/app/Filament/Concerns/HasCachedNavigationBadge.php
+++ b/app/Filament/Concerns/HasCachedNavigationBadge.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Filament\Concerns;
+
+use Illuminate\Support\Str;
+
+/** Caches the badge count, which otherwise runs per resource on every page load. */
+trait HasCachedNavigationBadge
+{
+    public static function getNavigationBadge(): ?string
+    {
+        return short_number(cache()->remember(
+            'filament:nav-badge:'.Str::replace('\\', '.', static::class),
+            now()->addMinutes(5),
+            fn (): int => static::navigationBadgeCount(),
+        ));
+    }
+
+    protected static function navigationBadgeCount(): int
+    {
+        return static::getModel()::query()->count();
+    }
+}

--- a/app/Filament/Concerns/HasDateFilters.php
+++ b/app/Filament/Concerns/HasDateFilters.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Filament\Widgets\Concerns;
+namespace App\Filament\Concerns;
 
 use App\Models\User;
 use Carbon\Carbon;
@@ -8,15 +8,17 @@ use Carbon\CarbonPeriod;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Select;
 use Filament\Schemas\Components\Grid;
-use Filament\Schemas\Components\Utilities\Set;
+use Filament\Schemas\Schema;
+use Filament\Widgets\ChartWidget\Concerns\HasFiltersSchema;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
 
+/** Shared date filtering for the dashboard trend widgets. */
 trait HasDateFilters
 {
-    private const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    use HasFiltersSchema;
 
-    private const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+    private const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
     private const QUICK_FILTERS = [
         'all' => 'All Time',
@@ -24,18 +26,29 @@ trait HasDateFilters
         'week' => 'This Week',
         'month' => 'This Month',
         'year' => 'This Year',
+        'custom' => 'Custom Range',
     ];
+
+    /** Deferring keeps the filter popover open: adjusting a filter costs no round trip. */
+    protected bool $hasDeferredFilters = true;
+
+    /** Polling re-renders the widget, which closes the filter popover mid-use. */
+    protected ?string $pollingInterval = null;
+
+    public function filtersSchema(Schema $schema): Schema
+    {
+        return $schema->components($this->getDateFiltersSchema());
+    }
 
     public function getTrendConfig(): array
     {
+        $filter = $this->filters['filter'] ?? 'all';
         $customStart = $this->filters['customStart'] ?? null;
         $customEnd = $this->filters['customEnd'] ?? null;
 
-        if ($customStart && $customEnd) {
+        if ($filter === 'custom' && filled($customStart) && filled($customEnd)) {
             return $this->buildCustomRangeConfig($customStart, $customEnd);
         }
-
-        $filter = $this->filters['filter'] ?? 'all';
 
         return match ($filter) {
             'day' => $this->buildDayConfig(),
@@ -53,19 +66,20 @@ trait HasDateFilters
                 ->label('Quick Filter')
                 ->options(self::QUICK_FILTERS)
                 ->default('all')
-                ->live()
-                ->afterStateUpdated(function (Set $set) {
-                    $this->filters['customStart'] = null;
-                    $this->filters['customEnd'] = null;
-                    $this->dispatch('$refresh');
-                }),
+                ->selectablePlaceholder(false),
             Grid::make(2)->schema([
                 DatePicker::make('customStart')
                     ->label('From')
-                    ->maxDate(now()),
+                    ->maxDate(now())
+                    ->visibleJs(<<<'JS'
+                        $get('filter') === 'custom'
+                        JS),
                 DatePicker::make('customEnd')
                     ->label('To')
-                    ->maxDate(now()),
+                    ->maxDate(now())
+                    ->visibleJs(<<<'JS'
+                        $get('filter') === 'custom'
+                        JS),
             ]),
         ];
     }
@@ -82,20 +96,19 @@ trait HasDateFilters
     private function buildWeekConfig(): array
     {
         $now = $this->userNow();
+        $start = $now->copy()->startOfWeek();
+        $end = $now->copy()->endOfWeek();
 
-        return $this->config($now->copy()->startOfWeek(), $now->copy()->endOfWeek(), 'perDay', self::DAY_LABELS);
+        return $this->config($start, $end, 'perDay', $this->dateRangeLabels($start, $end, 'D'));
     }
 
     private function buildMonthConfig(): array
     {
         $now = $this->userNow();
+        $start = $now->copy()->startOfMonth();
+        $end = $now->copy()->endOfMonth();
 
-        return $this->config(
-            $now->copy()->startOfMonth(),
-            $now->copy()->endOfMonth(),
-            'perDay',
-            $this->daysInMonthLabels($now->daysInMonth),
-        );
+        return $this->config($start, $end, 'perDay', $this->dateRangeLabels($start, $end, 'j'));
     }
 
     private function buildYearConfig(): array
@@ -108,11 +121,13 @@ trait HasDateFilters
     private function buildAllTimeConfig(): array
     {
         $tz = $this->userTimezone();
-        $start = User::query()->oldest()->first()?->created_at?->tz($tz)?->startOfMonth()
-            ?? now()->tz($tz)->startOfYear();
+        $oldest = User::query()->min('created_at');
+        $start = $oldest
+            ? Carbon::parse($oldest)->tz($tz)->startOfMonth()
+            : now()->tz($tz)->startOfYear();
         $end = now()->tz($tz)->endOfMonth();
 
-        if ($start->diffInMonths($end) > 24) {
+        if ($start->diffInMonths($end, absolute: true) > 24) {
             $yearStart = $start->copy()->startOfYear();
             $yearEnd = $end->copy()->endOfYear();
 
@@ -122,17 +137,26 @@ trait HasDateFilters
         return $this->config($start, $end, 'perMonth', $this->dateRangeLabels($start, $end, 'M Y', '1 month'));
     }
 
+    /** Avoids perWeek: PHP uses ISO weeks and MySQL uses %u, so labels desync from the data. */
     private function buildCustomRangeConfig(string $customStart, string $customEnd): array
     {
         $tz = $this->userTimezone();
         $start = Carbon::parse($customStart, $tz)->startOfDay();
         $end = Carbon::parse($customEnd, $tz)->endOfDay();
-        $days = $start->diffInDays($end);
+
+        if ($start->greaterThan($end)) {
+            [$start, $end] = [$end->copy()->startOfDay(), $start->copy()->endOfDay()];
+        }
+
+        if ($start->isSameDay($end)) {
+            return $this->config($start, $end, 'perHour', $this->hourLabels());
+        }
+
+        $days = $start->diffInDays($end, absolute: true);
 
         [$period, $labels] = match (true) {
-            $days <= 1 => ['perHour', $this->hourLabels()],
             $days <= 31 => ['perDay', $this->dateRangeLabels($start, $end, 'j')],
-            $days <= 365 => ['perWeek', $this->dateRangeLabels($start, $end, 'M j', '1 week')],
+            $days <= 365 => ['perDay', $this->dateRangeLabels($start, $end, 'M j')],
             default => ['perMonth', $this->dateRangeLabels($start, $end, 'M Y', '1 month')],
         };
 
@@ -167,13 +191,6 @@ trait HasDateFilters
     {
         return collect(range(0, 23))
             ->map(fn (int $hour) => Str::padLeft($hour, 2, '0').':00')
-            ->toArray();
-    }
-
-    private function daysInMonthLabels(int $daysInMonth): array
-    {
-        return collect(range(1, $daysInMonth))
-            ->map(fn (int $day) => (string) $day)
             ->toArray();
     }
 }

--- a/app/Filament/Resources/ApplicationDashboards/ApplicationDashboardResource.php
+++ b/app/Filament/Resources/ApplicationDashboards/ApplicationDashboardResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\ApplicationDashboards;
 
+use App\Filament\Concerns\HasCachedNavigationBadge;
 use App\Filament\Resources\ApplicationDashboards\Pages\ManageApplicationDashboards;
 use App\Models\ApplicationDashboard;
 use BackedEnum;
@@ -18,6 +19,8 @@ use UnitEnum;
 
 class ApplicationDashboardResource extends Resource
 {
+    use HasCachedNavigationBadge;
+
     protected static ?string $model = ApplicationDashboard::class;
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRocketLaunch;
@@ -40,7 +43,8 @@ class ApplicationDashboardResource extends Resource
                     ->maxLength(255),
                 TextInput::make('slideshow_speed')
                     ->required()
-                    ->maxLength(255),
+                    ->numeric()
+                    ->minValue(1),
                 Textarea::make('seo_terms')
                     ->helperText('Comma-separated SEO keywords rendered in the meta keywords tag.')
                     ->columnSpanFull(),
@@ -91,10 +95,5 @@ class ApplicationDashboardResource extends Resource
         return [
             'index' => ManageApplicationDashboards::route('/'),
         ];
-    }
-
-    public static function getNavigationBadge(): ?string
-    {
-        return short_number(static::getModel()::count());
     }
 }

--- a/app/Filament/Resources/Artists/ArtistResource.php
+++ b/app/Filament/Resources/Artists/ArtistResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Artists;
 
+use App\Filament\Concerns\HasCachedNavigationBadge;
 use App\Filament\Resources\Artists\Pages\ListArtists;
 use App\Filament\Resources\Artists\Pages\ViewArtist;
 use App\Filament\Resources\Artists\RelationManagers\RankingsRelationManager;
@@ -17,20 +18,18 @@ use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\ImageColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use UnitEnum;
 
 class ArtistResource extends Resource
 {
+    use HasCachedNavigationBadge;
+
     protected static ?string $model = Artist::class;
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedMusicalNote;
 
     protected static string|UnitEnum|null $navigationGroup = 'Song Rank';
-
-    public static function form(Schema $schema): Schema
-    {
-        return $schema->components([]);
-    }
 
     public static function table(Table $table): Table
     {
@@ -45,7 +44,7 @@ class ArtistResource extends Resource
                     ->sortable(),
                 TextColumn::make('rankings_count')
                     ->label('Rankings')
-                    ->counts(['rankings' => fn ($query) => $query->whereNull('playlist_id')])
+                    ->counts('rankings')
                     ->sortable(),
                 TextColumn::make('created_at')
                     ->dateTime()
@@ -61,7 +60,7 @@ class ArtistResource extends Resource
             ->toolbarActions([]);
     }
 
-    public static function infoList(Schema $schema): Schema
+    public static function infolist(Schema $schema): Schema
     {
         return $schema
             ->components([
@@ -77,10 +76,14 @@ class ArtistResource extends Resource
                         TextEntry::make('artist_id')
                             ->label('Spotify ID'),
                         TextEntry::make('rankings_count')
-                            ->label('Artist Rankings')
-                            ->state(fn (Artist $record) => $record->rankings()->whereNull('playlist_id')->count()),
+                            ->label('Artist Rankings'),
                     ]),
             ]);
+    }
+
+    public static function getRecordRouteBindingEloquentQuery(): Builder
+    {
+        return parent::getRecordRouteBindingEloquentQuery()->withCount('rankings');
     }
 
     public static function getRelations(): array
@@ -96,10 +99,5 @@ class ArtistResource extends Resource
             'index' => ListArtists::route('/'),
             'view' => ViewArtist::route('/{record}'),
         ];
-    }
-
-    public static function getNavigationBadge(): ?string
-    {
-        return short_number(static::getModel()::count());
     }
 }

--- a/app/Filament/Resources/Artists/RelationManagers/RankingsRelationManager.php
+++ b/app/Filament/Resources/Artists/RelationManagers/RankingsRelationManager.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\Artists\RelationManagers;
 
 use App\Filament\Resources\Rankings\RankingResource;
 use App\Filament\Resources\Rankings\Tables\RankingTable;
+use App\Models\Ranking;
 use Filament\Actions\ViewAction;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Table;
@@ -16,10 +17,9 @@ class RankingsRelationManager extends RelationManager
     {
         return RankingTable::configure($table)
             ->recordTitleAttribute('name')
-            ->modifyQueryUsing(fn ($query) => $query->whereNull('playlist_id')->whereNull('show_id'))
             ->recordActions([
                 ViewAction::make()
-                    ->url(fn ($record) => RankingResource::getUrl('view', ['record' => $record])),
+                    ->url(fn (Ranking $record): string => RankingResource::getUrl('view', ['record' => $record])),
             ])
             ->toolbarActions([]);
     }

--- a/app/Filament/Resources/Comments/CommentResource.php
+++ b/app/Filament/Resources/Comments/CommentResource.php
@@ -2,21 +2,26 @@
 
 namespace App\Filament\Resources\Comments;
 
+use App\Filament\Concerns\HasCachedNavigationBadge;
 use App\Filament\Resources\Comments\Pages\EditComment;
 use App\Filament\Resources\Comments\Pages\ListComments;
 use App\Filament\Resources\Comments\Pages\ViewComment;
 use App\Filament\Resources\Comments\Schemas\CommentInfolist;
 use App\Filament\Resources\Comments\Tables\CommentsTable;
+use App\Models\Comment;
 use BackedEnum;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Textarea;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
-use Spatie\Comments\Models\Comment;
 use UnitEnum;
 
 class CommentResource extends Resource
 {
+    use HasCachedNavigationBadge;
+
     protected static ?string $model = Comment::class;
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
@@ -24,6 +29,20 @@ class CommentResource extends Resource
     protected static string|UnitEnum|null $navigationGroup = 'Song Rank';
 
     protected static ?string $recordTitleAttribute = 'id';
+
+    /** Edit only. Comments are never created here: there is no create page or action. */
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Textarea::make('original_text')
+                ->label('Comment')
+                ->required()
+                ->rows(5)
+                ->columnSpanFull(),
+            DateTimePicker::make('approved_at')
+                ->label('Approved At'),
+        ]);
+    }
 
     public static function infolist(Schema $schema): Schema
     {
@@ -49,10 +68,5 @@ class CommentResource extends Resource
             'view' => ViewComment::route('/{record}'),
             'edit' => EditComment::route('/{record}/edit'),
         ];
-    }
-
-    public static function getNavigationBadge(): ?string
-    {
-        return short_number(static::getModel()::count());
     }
 }

--- a/app/Filament/Resources/Comments/Pages/ListComments.php
+++ b/app/Filament/Resources/Comments/Pages/ListComments.php
@@ -3,17 +3,9 @@
 namespace App\Filament\Resources\Comments\Pages;
 
 use App\Filament\Resources\Comments\CommentResource;
-use Filament\Actions\CreateAction;
 use Filament\Resources\Pages\ListRecords;
 
 class ListComments extends ListRecords
 {
     protected static string $resource = CommentResource::class;
-
-    protected function getHeaderActions(): array
-    {
-        return [
-            CreateAction::make(),
-        ];
-    }
 }

--- a/app/Filament/Resources/Comments/Schemas/CommentInfolist.php
+++ b/app/Filament/Resources/Comments/Schemas/CommentInfolist.php
@@ -2,10 +2,11 @@
 
 namespace App\Filament\Resources\Comments\Schemas;
 
-use Filament\Schemas\Schema;
-use Filament\Schemas\Components\Section;
-use Filament\Infolists\Components\TextEntry;
+use App\Models\Comment;
 use Filament\Infolists\Components\KeyValueEntry;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 
 class CommentInfolist
@@ -40,11 +41,15 @@ class CommentInfolist
                         TextEntry::make('commentator.name')
                             ->label('User')
                             ->icon(Heroicon::Link)
-                            ->url(fn ($record) => $record->commentator ? route('filament.admin.resources.users.edit', $record->commentator_id) : null),
+                            ->url(fn (Comment $record): ?string => $record->commentator
+                                ? route('filament.admin.resources.users.edit', $record->commentator_id)
+                                : null),
                         TextEntry::make('commentable.name')
                             ->label('Ranking')
                             ->icon(Heroicon::Link)
-                            ->url(fn ($record) => $record->commentable ? route('filament.admin.resources.rankings.edit', $record->commentator_id) : null),
+                            ->url(fn (Comment $record): ?string => $record->commentable
+                                ? route('filament.admin.resources.rankings.edit', $record->commentable_id)
+                                : null),
                     ]),
 
                 Section::make('Status & Timestamps')
@@ -54,8 +59,8 @@ class CommentInfolist
                             ->label('Approved')
                             ->dateTime()
                             ->placeholder('Not Approved')
-                            ->icon(fn ($state) => $state ? Heroicon::OutlinedCheckCircle : Heroicon::OutlinedXCircle)
-                            ->iconColor(fn ($state) => $state ? 'success' : 'danger'),
+                            ->icon(fn (mixed $state): Heroicon => $state ? Heroicon::OutlinedCheckCircle : Heroicon::OutlinedXCircle)
+                            ->iconColor(fn (mixed $state): string => $state ? 'success' : 'danger'),
                         TextEntry::make('created_at')
                             ->dateTime()
                             ->since(),

--- a/app/Filament/Resources/Comments/Tables/CommentsTable.php
+++ b/app/Filament/Resources/Comments/Tables/CommentsTable.php
@@ -29,13 +29,13 @@ class CommentsTable
                     ->label('Created At')
                     ->dateTime(
                         format: 'M j, Y g:i A T',
-                        timezone: Auth::user()->timezone
+                        timezone: Auth::user()->timezone,
                     ),
                 TextColumn::make('updated_at')
                     ->label('Updated At')
                     ->dateTime(
                         format: 'M j, Y g:i A T',
-                        timezone: Auth::user()->timezone
+                        timezone: Auth::user()->timezone,
                     ),
             ])
             ->filters([

--- a/app/Filament/Resources/EmailTemplates/EmailTemplateResource.php
+++ b/app/Filament/Resources/EmailTemplates/EmailTemplateResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\EmailTemplates;
 
+use App\Filament\Concerns\HasCachedNavigationBadge;
 use App\Filament\Resources\EmailTemplates\Pages\ManageEmailTemplates;
 use App\Jobs\SendEmailJob;
 use App\Models\EmailTemplate;
@@ -22,6 +23,8 @@ use UnitEnum;
 
 class EmailTemplateResource extends Resource
 {
+    use HasCachedNavigationBadge;
+
     protected static ?string $model = EmailTemplate::class;
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedPaperAirplane;
@@ -32,8 +35,12 @@ class EmailTemplateResource extends Resource
     {
         return $schema
             ->components([
-                TextInput::make('name'),
-                TextInput::make('subject'),
+                TextInput::make('name')
+                    ->required()
+                    ->maxLength(255),
+                TextInput::make('subject')
+                    ->required()
+                    ->maxLength(255),
                 RichEditor::make('content'),
             ])
             ->columns(1);
@@ -79,10 +86,5 @@ class EmailTemplateResource extends Resource
         return [
             'index' => ManageEmailTemplates::route('/'),
         ];
-    }
-
-    public static function getNavigationBadge(): ?string
-    {
-        return short_number(static::getModel()::count());
     }
 }

--- a/app/Filament/Resources/Faqs/FaqResource.php
+++ b/app/Filament/Resources/Faqs/FaqResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Faqs;
 
+use App\Filament\Concerns\HasCachedNavigationBadge;
 use App\Filament\Resources\Faqs\Pages\CreateFaq;
 use App\Filament\Resources\Faqs\Pages\EditFaq;
 use App\Filament\Resources\Faqs\Pages\ListFaqs;
@@ -19,6 +20,8 @@ use UnitEnum;
 
 class FaqResource extends Resource
 {
+    use HasCachedNavigationBadge;
+
     protected static ?string $model = Faq::class;
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::QuestionMarkCircle;
@@ -52,10 +55,5 @@ class FaqResource extends Resource
             ->withoutGlobalScopes([
                 SoftDeletingScope::class,
             ]);
-    }
-
-    public static function getNavigationBadge(): ?string
-    {
-        return short_number(Faq::count());
     }
 }

--- a/app/Filament/Resources/LandingPageContents/LandingPageContentResource.php
+++ b/app/Filament/Resources/LandingPageContents/LandingPageContentResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\LandingPageContents;
 
+use App\Filament\Concerns\HasCachedNavigationBadge;
 use App\Filament\Resources\LandingPageContents\Pages\EditLandingPageContent;
 use App\Filament\Resources\LandingPageContents\Pages\ListLandingPageContents;
 use App\Filament\Resources\LandingPageContents\Schemas\LandingPageContentForm;
@@ -18,6 +19,8 @@ use UnitEnum;
 
 class LandingPageContentResource extends Resource
 {
+    use HasCachedNavigationBadge;
+
     protected static ?string $model = LandingPageContent::class;
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::DocumentText;
@@ -50,10 +53,5 @@ class LandingPageContentResource extends Resource
             ->withoutGlobalScopes([
                 SoftDeletingScope::class,
             ]);
-    }
-
-    public static function getNavigationBadge(): ?string
-    {
-        return short_number(LandingPageContent::count());
     }
 }

--- a/app/Filament/Resources/Playlists/Pages/ManagePlaylists.php
+++ b/app/Filament/Resources/Playlists/Pages/ManagePlaylists.php
@@ -8,9 +8,4 @@ use Filament\Resources\Pages\ManageRecords;
 class ManagePlaylists extends ManageRecords
 {
     protected static string $resource = PlaylistResource::class;
-
-    protected function getHeaderActions(): array
-    {
-        return [];
-    }
 }

--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Playlists;
 
+use App\Filament\Concerns\HasCachedNavigationBadge;
 use App\Filament\Resources\Playlists\Pages\ManagePlaylists;
 use App\Models\Playlist;
 use BackedEnum;
@@ -21,6 +22,8 @@ use UnitEnum;
 
 class PlaylistResource extends Resource
 {
+    use HasCachedNavigationBadge;
+
     protected static ?string $model = Playlist::class;
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::RectangleGroup;
@@ -28,11 +31,6 @@ class PlaylistResource extends Resource
     protected static string|UnitEnum|null $navigationGroup = 'Song Rank';
 
     protected static ?string $recordTitleAttribute = 'name';
-
-    public static function form(Schema $schema): Schema
-    {
-        return $schema->components([]);
-    }
 
     public static function infolist(Schema $schema): Schema
     {
@@ -64,7 +62,9 @@ class PlaylistResource extends Resource
                             ->color('primary'),
                         TextEntry::make('creator_name')
                             ->label('Creator Name')
-                            ->url(fn (Playlist $playlist) => route('filament.admin.resources.users.view', ['record' => $playlist->user]))
+                            ->url(fn (Playlist $playlist): ?string => $playlist->user
+                                ? route('filament.admin.resources.users.view', ['record' => $playlist->user])
+                                : null)
                             ->color('primary')
                             ->icon(Heroicon::User),
                     ]),
@@ -123,10 +123,5 @@ class PlaylistResource extends Resource
             ->withoutGlobalScopes([
                 SoftDeletingScope::class,
             ]);
-    }
-
-    public static function getNavigationBadge(): ?string
-    {
-        return short_number(Playlist::count());
     }
 }

--- a/app/Filament/Resources/Rankings/RankingResource.php
+++ b/app/Filament/Resources/Rankings/RankingResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Rankings;
 
+use App\Filament\Concerns\HasCachedNavigationBadge;
 use App\Filament\Resources\Rankings\Pages\EditRanking;
 use App\Filament\Resources\Rankings\Pages\ListRankings;
 use App\Filament\Resources\Rankings\Pages\ViewRanking;
@@ -12,7 +13,7 @@ use App\Models\Ranking;
 use BackedEnum;
 use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
-use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Infolists\Components\IconEntry;
@@ -21,11 +22,16 @@ use Filament\Resources\Resource;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Filters\TrashedFilter;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
 use UnitEnum;
 
 class RankingResource extends Resource
 {
+    use HasCachedNavigationBadge;
+
     protected static ?string $model = Ranking::class;
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::ListBullet;
@@ -38,20 +44,24 @@ class RankingResource extends Resource
             TextInput::make('name')
                 ->required()
                 ->maxLength(255),
-            DatePicker::make('completed_at')
-                ->label('Completed At'),
+            DateTimePicker::make('completed_at')
+                ->label('Completed At')
+                ->afterStateHydrated(function (DateTimePicker $component, ?Ranking $record): void {
+                    $component->state($record?->getAttributes()['completed_at'] ?? null);
+                }),
             Toggle::make('is_ranked')
-                ->label('Is Ranked')
-                ->required(),
+                ->label('Is Ranked'),
             Toggle::make('is_public')
-                ->label('Is Public')
-                ->required(),
+                ->label('Is Public'),
         ]);
     }
 
     public static function table(Table $table): Table
     {
         return RankingTable::configure($table)
+            ->filters([
+                TrashedFilter::make(),
+            ])
             ->recordActions([
                 ViewAction::make(),
                 EditAction::make(),
@@ -59,7 +69,7 @@ class RankingResource extends Resource
             ->toolbarActions([]);
     }
 
-    public static function infoList(Schema $schema): Schema
+    public static function infolist(Schema $schema): Schema
     {
         return $schema
             ->components([
@@ -98,8 +108,7 @@ class RankingResource extends Resource
                         TextEntry::make('playlist.track_count')
                             ->label('Tracks in Playlist'),
                         TextEntry::make('songs_count')
-                            ->label('Tracks Ranked')
-                            ->state(fn (Ranking $ranking) => $ranking->songs()->count()),
+                            ->label('Tracks Ranked'),
                     ]),
 
                 Section::make('Show Details')
@@ -137,13 +146,18 @@ class RankingResource extends Resource
         ];
     }
 
-    public static function getNavigationBadge(): ?string
+    /** The table counts its own songs; RankingTable is shared with relation managers. */
+    public static function getRecordRouteBindingEloquentQuery(): Builder
     {
-        return short_number(
-            Ranking::query()
-                ->where('is_ranked', true)
-                ->where('is_public', true)
-                ->count()
-        );
+        return parent::getRecordRouteBindingEloquentQuery()
+            ->withCount('songs')
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
+            ]);
+    }
+
+    protected static function navigationBadgeCount(): int
+    {
+        return Ranking::query()->public()->completed()->count();
     }
 }

--- a/app/Filament/Resources/Rankings/RelationManagers/CommentsRelationManager.php
+++ b/app/Filament/Resources/Rankings/RelationManagers/CommentsRelationManager.php
@@ -2,12 +2,12 @@
 
 namespace App\Filament\Resources\Rankings\RelationManagers;
 
-use Filament\Tables\Table;
-use Filament\Actions\ViewAction;
+use App\Filament\Resources\Comments\CommentResource;
 use Filament\Actions\DeleteAction;
-use Filament\Tables\Columns\TextColumn;
-use App\Filament\Resources\Rankings\RankingResource;
+use Filament\Actions\ViewAction;
 use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
 
 class CommentsRelationManager extends RelationManager
 {
@@ -15,7 +15,7 @@ class CommentsRelationManager extends RelationManager
 
     protected static ?string $title = 'Comments';
 
-    protected static ?string $relatedResource = RankingResource::class;
+    protected static ?string $relatedResource = CommentResource::class;
 
     public function table(Table $table): Table
     {
@@ -33,7 +33,7 @@ class CommentsRelationManager extends RelationManager
                     ->sortable(),
             ])
             ->defaultSort('created_at', 'desc')
-            ->recordactions([
+            ->recordActions([
                 ViewAction::make(),
                 DeleteAction::make(),
             ]);

--- a/app/Filament/Resources/Rankings/RelationManagers/SongsRelationManager.php
+++ b/app/Filament/Resources/Rankings/RelationManagers/SongsRelationManager.php
@@ -4,7 +4,6 @@ namespace App\Filament\Resources\Rankings\RelationManagers;
 
 use Filament\Actions\DeleteAction;
 use Filament\Resources\RelationManagers\RelationManager;
-use Filament\Schemas\Schema;
 use Filament\Tables\Columns\ImageColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Columns\TextInputColumn;
@@ -13,11 +12,6 @@ use Filament\Tables\Table;
 class SongsRelationManager extends RelationManager
 {
     protected static string $relationship = 'songs';
-
-    public function form(Schema $schema): Schema
-    {
-        return $schema->components([]);
-    }
 
     public function table(Table $table): Table
     {

--- a/app/Filament/Resources/Rankings/Tables/RankingTable.php
+++ b/app/Filament/Resources/Rankings/Tables/RankingTable.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Rankings\Tables;
 
+use App\Models\Ranking;
 use Carbon\Carbon;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
@@ -46,7 +47,6 @@ class RankingTable
             IconColumn::make('is_ranked')
                 ->label('Is Ranked')
                 ->boolean()
-                ->searchable()
                 ->sortable()
                 ->trueIcon('heroicon-o-check-badge')
                 ->falseIcon('heroicon-o-x-mark')
@@ -54,14 +54,12 @@ class RankingTable
             IconColumn::make('is_public')
                 ->label('Is Public')
                 ->boolean()
-                ->searchable()
                 ->sortable()
                 ->trueIcon('heroicon-o-check-badge')
                 ->falseIcon('heroicon-o-x-mark')
                 ->toggleable(isToggledHiddenByDefault: false),
             TextColumn::make('created_at')
                 ->label('Created')
-                ->searchable()
                 ->sortable()
                 ->dateTime()
                 ->toggleable(isToggledHiddenByDefault: false),
@@ -77,11 +75,10 @@ class RankingTable
     {
         return TextColumn::make('completed_at')
             ->label('Completed')
-            ->searchable()
             ->sortable()
             ->dateTime()
             ->toggleable(isToggledHiddenByDefault: false)
-            ->formatStateUsing(function ($state, $record) {
+            ->formatStateUsing(function (Ranking $record): string {
                 $timestamp = $record->getAttributes()['completed_at'];
 
                 if (is_null($timestamp)) {

--- a/app/Filament/Resources/Shows/Pages/ViewShow.php
+++ b/app/Filament/Resources/Shows/Pages/ViewShow.php
@@ -3,9 +3,9 @@
 namespace App\Filament\Resources\Shows\Pages;
 
 use App\Filament\Resources\Shows\ShowResource;
-use Filament\Resources\Pages\ManageRecords;
+use Filament\Resources\Pages\ViewRecord;
 
-class ManageShows extends ManageRecords
+class ViewShow extends ViewRecord
 {
     protected static string $resource = ShowResource::class;
 }

--- a/app/Filament/Resources/Shows/RelationManagers/RankingsRelationManager.php
+++ b/app/Filament/Resources/Shows/RelationManagers/RankingsRelationManager.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\Shows\RelationManagers;
 
 use App\Filament\Resources\Rankings\RankingResource;
 use App\Filament\Resources\Rankings\Tables\RankingTable;
+use App\Models\Ranking;
 use Filament\Actions\ViewAction;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Table;
@@ -16,10 +17,9 @@ class RankingsRelationManager extends RelationManager
     {
         return RankingTable::configure($table)
             ->recordTitleAttribute('name')
-            ->modifyQueryUsing(fn ($query) => $query->whereNotNull('show_id'))
             ->recordActions([
                 ViewAction::make()
-                    ->url(fn ($record) => RankingResource::getUrl('view', ['record' => $record])),
+                    ->url(fn (Ranking $record): string => RankingResource::getUrl('view', ['record' => $record])),
             ])
             ->toolbarActions([]);
     }

--- a/app/Filament/Resources/Shows/ShowResource.php
+++ b/app/Filament/Resources/Shows/ShowResource.php
@@ -2,7 +2,9 @@
 
 namespace App\Filament\Resources\Shows;
 
+use App\Filament\Concerns\HasCachedNavigationBadge;
 use App\Filament\Resources\Shows\Pages\ManageShows;
+use App\Filament\Resources\Shows\Pages\ViewShow;
 use App\Filament\Resources\Shows\RelationManagers\RankingsRelationManager;
 use App\Models\Show;
 use BackedEnum;
@@ -23,6 +25,8 @@ use UnitEnum;
 
 class ShowResource extends Resource
 {
+    use HasCachedNavigationBadge;
+
     protected static ?string $model = Show::class;
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::Microphone;
@@ -30,11 +34,6 @@ class ShowResource extends Resource
     protected static string|UnitEnum|null $navigationGroup = 'Song Rank';
 
     protected static ?string $recordTitleAttribute = 'name';
-
-    public static function form(Schema $schema): Schema
-    {
-        return $schema->components([]);
-    }
 
     public static function infolist(Schema $schema): Schema
     {
@@ -115,6 +114,7 @@ class ShowResource extends Resource
     {
         return [
             'index' => ManageShows::route('/'),
+            'view' => ViewShow::route('/{record}'),
         ];
     }
 
@@ -124,10 +124,5 @@ class ShowResource extends Resource
             ->withoutGlobalScopes([
                 SoftDeletingScope::class,
             ]);
-    }
-
-    public static function getNavigationBadge(): ?string
-    {
-        return short_number(Show::count());
     }
 }

--- a/app/Filament/Resources/Terms/Tables/TermsTable.php
+++ b/app/Filament/Resources/Terms/Tables/TermsTable.php
@@ -20,18 +20,14 @@ class TermsTable
                 TextColumn::make('id')->label('ID'),
                 TextColumn::make('created_at')
                     ->label('Created')
-                    ->searchable()
                     ->sortable()
                     ->dateTime(),
                 TextColumn::make('updated_at')
                     ->label('Last Updated')
-                    ->searchable()
                     ->sortable()
                     ->dateTime(),
             ])
-            ->filters([
-
-            ])
+            ->filters([])
             ->recordActions([
                 ViewAction::make(),
                 EditAction::make(),

--- a/app/Filament/Resources/Terms/TermsResource.php
+++ b/app/Filament/Resources/Terms/TermsResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Terms;
 
+use App\Filament\Concerns\HasCachedNavigationBadge;
 use App\Filament\Resources\Terms\Pages\CreateTerms;
 use App\Filament\Resources\Terms\Pages\EditTerms;
 use App\Filament\Resources\Terms\Pages\ListTerms;
@@ -20,6 +21,8 @@ use UnitEnum;
 
 class TermsResource extends Resource
 {
+    use HasCachedNavigationBadge;
+
     protected static ?string $model = Terms::class;
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::Briefcase;
@@ -59,10 +62,5 @@ class TermsResource extends Resource
             ->withoutGlobalScopes([
                 SoftDeletingScope::class,
             ]);
-    }
-
-    public static function getNavigationBadge(): ?string
-    {
-        return short_number(static::getModel()::count());
     }
 }

--- a/app/Filament/Resources/Users/RelationManagers/RankingsRelationManager.php
+++ b/app/Filament/Resources/Users/RelationManagers/RankingsRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Users\RelationManagers;
 
+use App\Actions\Rankings\DestroyRanking;
 use App\Filament\Resources\Rankings\RankingResource;
 use App\Filament\Resources\Rankings\Tables\RankingTable;
 use App\Models\Ranking;
@@ -13,6 +14,7 @@ use Filament\Actions\ViewAction;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Collection;
 
 class RankingsRelationManager extends RelationManager
 {
@@ -25,7 +27,7 @@ class RankingsRelationManager extends RelationManager
 
     public function form(Schema $schema): Schema
     {
-        return $schema->components(Ranking::getAdminForm());
+        return RankingResource::form($schema);
     }
 
     public function table(Table $table): Table
@@ -34,14 +36,18 @@ class RankingsRelationManager extends RelationManager
             ->recordTitleAttribute('name')
             ->recordActions([
                 ViewAction::make()
-                    ->url(fn ($record) => RankingResource::getUrl('view', ['record' => $record])),
+                    ->url(fn (Ranking $record): string => RankingResource::getUrl('view', ['record' => $record])),
                 EditAction::make()
-                    ->url(fn ($record) => RankingResource::getUrl('edit', ['record' => $record])),
-                DeleteAction::make(),
+                    ->url(fn (Ranking $record): string => RankingResource::getUrl('edit', ['record' => $record])),
+                DeleteAction::make()
+                    ->using(fn (Ranking $record) => app(DestroyRanking::class)->handle($record->user, $record)),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->action(function (Collection $records): void {
+                            $records->each(fn (Ranking $record) => app(DestroyRanking::class)->handle($record->user, $record));
+                        }),
                 ]),
             ]);
     }

--- a/app/Filament/Resources/Users/UserResource.php
+++ b/app/Filament/Resources/Users/UserResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Users;
 
+use App\Filament\Concerns\HasCachedNavigationBadge;
 use App\Filament\Resources\Users\Pages\EditUser;
 use App\Filament\Resources\Users\Pages\ListUsers;
 use App\Filament\Resources\Users\Pages\ViewUser;
@@ -27,6 +28,8 @@ use UnitEnum;
 
 class UserResource extends Resource
 {
+    use HasCachedNavigationBadge;
+
     protected static ?string $model = User::class;
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedUser;
@@ -39,13 +42,15 @@ class UserResource extends Resource
             ->components([
                 TextInput::make('spotify_id')
                     ->required()
-                    ->maxLength(255),
+                    ->maxLength(255)
+                    ->unique(ignoreRecord: true),
                 TextInput::make('name')
                     ->required()
                     ->maxLength(255),
                 TextInput::make('email')
                     ->email()
-                    ->maxLength(255),
+                    ->maxLength(255)
+                    ->unique(ignoreRecord: true),
                 TextInput::make('timezone')
                     ->maxLength(255),
             ]);
@@ -168,10 +173,5 @@ class UserResource extends Resource
             'view' => ViewUser::route('/{record}'),
             'edit' => EditUser::route('/{record}/edit'),
         ];
-    }
-
-    public static function getNavigationBadge(): ?string
-    {
-        return short_number(static::getModel()::count());
     }
 }

--- a/app/Filament/Widgets/CommentsCreatedWidget.php
+++ b/app/Filament/Widgets/CommentsCreatedWidget.php
@@ -2,27 +2,19 @@
 
 namespace App\Filament\Widgets;
 
-use App\Filament\Widgets\Concerns\HasDateFilters;
-use Filament\Schemas\Schema;
+use App\Filament\Concerns\HasDateFilters;
+use App\Models\Comment;
 use Filament\Widgets\ChartWidget;
-use Filament\Widgets\ChartWidget\Concerns\HasFiltersSchema;
 use Flowframe\Trend\Trend;
 use Flowframe\Trend\TrendValue;
-use Spatie\Comments\Models\Comment;
 
 class CommentsCreatedWidget extends ChartWidget
 {
     use HasDateFilters;
-    use HasFiltersSchema;
 
     protected ?string $heading = 'Comment Stats';
 
     protected static ?int $sort = 6;
-
-    public function filtersSchema(Schema $schema): Schema
-    {
-        return $schema->components($this->getDateFiltersSchema());
-    }
 
     protected function getData(): array
     {
@@ -37,7 +29,7 @@ class CommentsCreatedWidget extends ChartWidget
             'datasets' => [
                 [
                     'label' => 'Comments Created',
-                    'data' => $created->map(fn(TrendValue $value) => $value->aggregate),
+                    'data' => $created->map(fn (TrendValue $value) => $value->aggregate),
                     'borderColor' => '#c084fc',
                 ],
             ],

--- a/app/Filament/Widgets/LoginsWidget.php
+++ b/app/Filament/Widgets/LoginsWidget.php
@@ -8,12 +8,16 @@ use Filament\Widgets\StatsOverviewWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Illuminate\Support\Facades\Auth;
 use Kyledoesdev\Essentials\Stats\LoginStat;
+use Spatie\Stats\DataPoint;
+use Spatie\Stats\Models\StatsEvent;
 
 class LoginsWidget extends StatsOverviewWidget
 {
     protected static ?int $sort = 1;
 
     protected ?string $heading = 'User Stats';
+
+    protected ?string $pollingInterval = null;
 
     protected function getStats(): array
     {
@@ -50,13 +54,15 @@ class LoginsWidget extends StatsOverviewWidget
         ];
     }
 
+    /** Sums increments directly; StatsQuery buckets by week and costs several queries. */
     private function loginsBetween(Carbon $start, Carbon $end): int
     {
-        return LoginStat::query()
-            ->start($start)
-            ->end($end)
-            ->get()
-            ->sum('increments');
+        return (int) StatsEvent::query()
+            ->where('name', (new LoginStat)->getName())
+            ->where('type', DataPoint::TYPE_CHANGE)
+            ->where('value', '>', 0)
+            ->whereBetween('created_at', [$start, $end])
+            ->sum('value');
     }
 
     private function trendStat(string $label, int $current, int $previous, string $comparedTo): Stat

--- a/app/Filament/Widgets/NewUsersWidget.php
+++ b/app/Filament/Widgets/NewUsersWidget.php
@@ -2,29 +2,19 @@
 
 namespace App\Filament\Widgets;
 
-use App\Filament\Widgets\Concerns\HasDateFilters;
+use App\Filament\Concerns\HasDateFilters;
 use App\Models\User;
-use Filament\Schemas\Schema;
 use Filament\Widgets\ChartWidget;
-use Filament\Widgets\ChartWidget\Concerns\HasFiltersSchema;
 use Flowframe\Trend\Trend;
 use Flowframe\Trend\TrendValue;
 
 class NewUsersWidget extends ChartWidget
 {
     use HasDateFilters;
-    use HasFiltersSchema;
 
-    protected ?string $heading = 'New Users Widget';
+    protected ?string $heading = 'New Users';
 
     protected static ?int $sort = 2;
-
-    protected bool $hasDeferredFilters = true;
-
-    public function filtersSchema(Schema $schema): Schema
-    {
-        return $schema->components($this->getDateFiltersSchema());
-    }
 
     protected function getData(): array
     {
@@ -36,6 +26,7 @@ class NewUsersWidget extends ChartWidget
             ->count();
 
         $deletedUsers = Trend::query(User::onlyTrashed())
+            ->dateColumn('deleted_at')
             ->between(start: $trendConfig['start'], end: $trendConfig['end'])
             ->{$trendConfig['period']}()
             ->count();

--- a/app/Filament/Widgets/RankingsCreatedWidget.php
+++ b/app/Filament/Widgets/RankingsCreatedWidget.php
@@ -2,29 +2,19 @@
 
 namespace App\Filament\Widgets;
 
-use App\Filament\Widgets\Concerns\HasDateFilters;
+use App\Filament\Concerns\HasDateFilters;
 use App\Models\Ranking;
-use Filament\Schemas\Schema;
 use Filament\Widgets\ChartWidget;
-use Filament\Widgets\ChartWidget\Concerns\HasFiltersSchema;
 use Flowframe\Trend\Trend;
 use Flowframe\Trend\TrendValue;
 
 class RankingsCreatedWidget extends ChartWidget
 {
     use HasDateFilters;
-    use HasFiltersSchema;
 
     protected ?string $heading = 'Rankings Stats';
 
     protected static ?int $sort = 3;
-
-    protected bool $hasDeferredFilters = true;
-
-    public function filtersSchema(Schema $schema): Schema
-    {
-        return $schema->components($this->getDateFiltersSchema());
-    }
 
     protected function getData(): array
     {
@@ -36,11 +26,13 @@ class RankingsCreatedWidget extends ChartWidget
             ->count();
 
         $deleted = Trend::query(Ranking::onlyTrashed())
+            ->dateColumn('deleted_at')
             ->between(start: $trendConfig['start'], end: $trendConfig['end'])
             ->{$trendConfig['period']}()
             ->count();
 
         $completed = Trend::query(Ranking::query()->whereNotNull('completed_at'))
+            ->dateColumn('completed_at')
             ->between(start: $trendConfig['start'], end: $trendConfig['end'])
             ->{$trendConfig['period']}()
             ->count();

--- a/app/Filament/Widgets/UserGeographyWidget.php
+++ b/app/Filament/Widgets/UserGeographyWidget.php
@@ -16,6 +16,8 @@ class UserGeographyWidget extends ChartWidget
 
     protected static ?int $sort = 4;
 
+    protected ?string $pollingInterval = null;
+
     protected function getFilters(): ?array
     {
         return [
@@ -49,7 +51,8 @@ class UserGeographyWidget extends ChartWidget
 
     protected function getGroupedData(): Collection
     {
-        $packets = User::whereNotNull('user_packet')
+        $packets = User::query()
+            ->whereNotNull('user_packet')
             ->pluck('user_packet')
             ->map(fn ($packet) => (array) (is_string($packet) ? json_decode($packet) : $packet))
             ->filter();
@@ -70,7 +73,7 @@ class UserGeographyWidget extends ChartWidget
 
     protected function countryToContinent(?string $code): ?string
     {
-        if (!$code) {
+        if (! $code) {
             return null;
         }
 

--- a/app/Filament/Widgets/UserPlatformWidget.php
+++ b/app/Filament/Widgets/UserPlatformWidget.php
@@ -4,6 +4,9 @@ namespace App\Filament\Widgets;
 
 use App\Models\User;
 use Filament\Widgets\ChartWidget;
+use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 class UserPlatformWidget extends ChartWidget
 {
@@ -13,27 +16,29 @@ class UserPlatformWidget extends ChartWidget
 
     protected static ?int $sort = 5;
 
+    protected ?string $pollingInterval = null;
+
+    /** iOS reports no platform client hint, so those users are read off the user agent instead. */
     protected function getData(): array
     {
+        $iphones = User::query()
+            ->where('user_agent', 'like', '%iPhone%')
+            ->count();
+
         $platforms = User::query()
-            ->select('user_platform', 'user_agent')
             ->whereNotNull('user_platform')
-            ->whereNotNull('user_agent')
             ->where('user_platform', '!=', '')
-            ->get()
-            ->map(function (User $user) {
-                $platform = strtolower(trim($user->user_platform, " \t\n\r\0\x0B\""));
-
-                if (str_contains($user->user_agent ?? '', 'iPhone')) {
-                    return 'iPhone';
-                }
-
-                return $platform;
-            })
+            ->where(fn (Builder $query) => $query
+                ->whereNull('user_agent')
+                ->orWhere('user_agent', 'not like', '%iPhone%'))
+            ->pluck('user_platform')
+            ->map(fn (string $platform) => Str::of($platform)->trim('"')->lower()->toString())
+            ->filter()
             ->countBy()
+            ->when($iphones > 0, fn (Collection $platforms) => $platforms->put('iphone', $iphones))
             ->sortDesc();
 
-        $colors = $platforms->keys()->map(fn ($platform) => $this->getPlatformColor($platform))->values();
+        $colors = $platforms->keys()->map(fn (string $platform) => $this->getPlatformColor($platform))->values();
 
         return [
             'datasets' => [
@@ -43,7 +48,7 @@ class UserPlatformWidget extends ChartWidget
                     'backgroundColor' => $colors->toArray(),
                 ],
             ],
-            'labels' => $platforms->keys()->map(fn ($p) => $this->formatLabel($p))->toArray(),
+            'labels' => $platforms->keys()->map(fn (string $platform) => $this->formatLabel($platform))->toArray(),
         ];
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -61,6 +61,7 @@ class User extends Authenticatable implements CanComment, FilamentUser
     {
         return [
             'user_packet' => 'object',
+            'is_dev' => 'boolean',
         ];
     }
 

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -10,13 +10,12 @@ use Filament\Navigation\NavigationGroup;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
-use Filament\Support\Facades\FilamentView;
+use Filament\Support\Enums\Width;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\StartSession;
-use Illuminate\Support\Facades\Blade;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
 use Kyledoesdev\Essentials\Middleware\IsDeveloper;
 
@@ -33,7 +32,8 @@ class AdminPanelProvider extends PanelProvider
                 'primary' => Color::Violet,
                 'gray' => Color::Slate,
             ])
-            ->maxContentWidth('full')
+            ->maxContentWidth(Width::Full)
+            ->brandName('songrank.dev')
             ->navigationGroups([
                 NavigationGroup::make('Song Rank')
                     ->collapsible(),
@@ -57,13 +57,6 @@ class AdminPanelProvider extends PanelProvider
             ->authMiddleware([
                 Authenticate::class,
                 IsDeveloper::class,
-            ]);
-    }
-
-    public function register(): void
-    {
-        parent::register();
-
-        FilamentView::registerRenderHook('panels::body.end', fn (): string => Blade::render("@vite('resources/js/app.js')"));
+            ], isPersistent: true);
     }
 }

--- a/tests/Feature/ChartWidgetsTest.php
+++ b/tests/Feature/ChartWidgetsTest.php
@@ -8,7 +8,7 @@ use Livewire\Livewire;
 
 describe('trend chart widgets', function () {
     test('renders without error', function (string $widget) {
-        $user = User::factory()->createOne(['timezone' => 'UTC']);
+        $user = User::factory()->createOne();
 
         Livewire::actingAs($user)
             ->test($widget)
@@ -20,7 +20,7 @@ describe('trend chart widgets', function () {
     ]);
 
     test('renders with each quick filter applied', function (string $filter) {
-        $user = User::factory()->createOne(['timezone' => 'UTC']);
+        $user = User::factory()->createOne();
 
         Livewire::actingAs($user)
             ->test(NewUsersWidget::class)
@@ -29,13 +29,13 @@ describe('trend chart widgets', function () {
     })->with(['all', 'day', 'week', 'month', 'year']);
 
     test('builds a dataset for new and deleted users', function () {
-        $actor = User::factory()->createOne(['timezone' => 'UTC']);
+        $actor = User::factory()->createOne();
         User::factory()->count(2)->create();
         User::factory()->count(1)->create()->each->delete();
 
         Livewire::actingAs($actor)
             ->test(NewUsersWidget::class)
             ->assertOk()
-            ->assertSee('New Users Widget');
+            ->assertSee('New Users');
     });
 });

--- a/tests/Feature/LoginsWidgetTest.php
+++ b/tests/Feature/LoginsWidgetTest.php
@@ -7,7 +7,7 @@ use Livewire\Livewire;
 
 describe('logins widget', function () {
     test('renders all stats', function () {
-        $user = User::factory()->createOne(['timezone' => 'UTC']);
+        $user = User::factory()->createOne();
 
         Livewire::actingAs($user)
             ->test(LoginsWidget::class)
@@ -19,7 +19,7 @@ describe('logins widget', function () {
     });
 
     test('counts total and deleted users', function () {
-        $actor = User::factory()->createOne(['timezone' => 'UTC']);
+        $actor = User::factory()->createOne();
         User::factory()->count(2)->create();
         User::factory()->count(3)->create()->each->delete();
 
@@ -30,7 +30,7 @@ describe('logins widget', function () {
     });
 
     test('reflects daily active users from login stats', function () {
-        $user = User::factory()->createOne(['timezone' => 'UTC']);
+        $user = User::factory()->createOne();
 
         LoginStat::increase(5);
 


### PR DESCRIPTION
- Keep chart filter popovers open by disabling widget polling and dropping the live() quick filter in favour of deferred filters
- Fix the playlist view crashing when the creator is not a registered user
- Stop ranking edits rewriting completed_at through the model accessor
- Trend the deleted and completed series on their own date columns
- Drop the public app.js render hook that overrode window.confirm
- Route admin ranking deletes through DestroyRanking
- Point CommentResource at App\Models\Comment and give it an edit form
- Include iOS users in the platform chart
- Cache navigation badges behind a shared concern
- Add a ViewShow page so the shows relation manager is reachable