### PR TITLE
Hotfix/fix artists table

### DIFF
--- a/app/Actions/Rankings/DestroyRanking.php
+++ b/app/Actions/Rankings/DestroyRanking.php
@@ -10,11 +10,13 @@ final class DestroyRanking
 {
     public function handle(User $user, Ranking $ranking)
     {
+        if ($ranking->is_public) {
+            cache()->forget('explore:total-rankings');
+        }
+
         DB::transaction(function () use ($ranking) {
             $ranking->songs()->delete();
             $ranking->delete();
         });
-
-        cache()->forget('explore:total-rankings');
     }
 }

--- a/app/Actions/Rankings/StoreArtistRanking.php
+++ b/app/Actions/Rankings/StoreArtistRanking.php
@@ -6,6 +6,7 @@ use App\Models\Artist;
 use App\Models\Ranking;
 use App\Models\Song;
 use App\Models\User;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
@@ -42,36 +43,15 @@ final class StoreArtistRanking
 
             $tracks = collect($attributes['tracks']);
 
-            /* "appears on" tracks belong to their primary artist, so those records need to exist.
-               They arrive without artwork; UpdateArtistImages backfills it. */
-            $primaryArtists = $tracks
-                ->filter(fn (array $song) => $song['featured_artist'] ?? false)
-                ->pluck('primary_artist')
-                ->unique('id')
-                ->values();
+            $artists = $this->resolveArtists($tracks);
 
-            Artist::upsert(
-                $primaryArtists->map(fn (array $primary) => [
-                    'artist_id' => $primary['id'],
-                    'artist_name' => $primary['name'],
-                    'created_at' => now(),
-                    'updated_at' => now(),
-                ])->all(),
-                ['artist_id'],
-                ['artist_name', 'updated_at']
-            );
-
-            $primaryArtistKeys = Artist::query()
-                ->whereIn('artist_id', $primaryArtists->pluck('id'))
-                ->pluck('id', 'artist_id');
-
-            $songs = $tracks->map(function ($song) use ($ranking, $artist, $primaryArtistKeys) {
+            $songs = $tracks->map(function ($song) use ($ranking, $artist, $artists) {
                 $isFeaturedTrack = $song['featured_artist'] ?? false;
 
                 return [
                     'ranking_id' => $ranking->getKey(),
                     'artist_id' => $isFeaturedTrack
-                        ? $primaryArtistKeys->get($song['primary_artist']['id'])
+                        ? $artists->get($song['primary_artist']['id'])
                         : $artist->getKey(),
                     'spotify_song_id' => $song['id'],
                     'uuid' => $song['uuid'],
@@ -88,5 +68,43 @@ final class StoreArtistRanking
 
             return $ranking;
         });
+    }
+
+    private function resolveArtists(Collection $tracks): Collection
+    {
+        $primaryTrackArtists = $tracks
+            ->filter(fn (array $song) => $song['featured_artist'] ?? false)
+            ->pluck('primary_artist')
+            ->unique('id')
+            ->values();
+
+        if ($primaryTrackArtists->isEmpty()) {
+            return collect();
+        }
+
+        $keys = Artist::query()
+            ->whereIn('artist_id', $primaryTrackArtists->pluck('id'))
+            ->pluck('id', 'artist_id');
+
+        /* Insert the ones we've never seen, in a single query. Upserting the whole set instead
+           would burn an auto-increment id for every row that already existed. */
+        $newArtists = $primaryTrackArtists->reject(fn (array $primary) => $keys->has($primary['id']));
+
+        if ($newArtists->isEmpty()) {
+            return $keys;
+        }
+
+        Artist::insertOrIgnore($newArtists->map(fn (array $primary) => [
+            'artist_id' => $primary['id'],
+            'artist_name' => $primary['name'],
+            'created_at' => now(),
+            'updated_at' => now(),
+        ])->all());
+
+        return $keys->merge(
+            Artist::query()
+                ->whereIn('artist_id', $newArtists->pluck('id'))
+                ->pluck('id', 'artist_id')
+        );
     }
 }

--- a/app/Actions/Rankings/StoreArtistRanking.php
+++ b/app/Actions/Rankings/StoreArtistRanking.php
@@ -16,21 +16,20 @@ final class StoreArtistRanking
     {
         return DB::transaction(function () use ($user, $attributes) {
             /* update or create the artist */
-            $artist = Artist::updateOrCreate([
+            $rankedArtist = Artist::updateOrCreate([
                 'artist_id' => data_get($attributes, 'artist.id'),
             ], [
                 'artist_name' => data_get($attributes, 'artist.name'),
                 'artist_img' => data_get($attributes, 'artist.cover'),
             ]);
 
-            /* update or create the artist */
             $name = $attributes['ranking_name'] === '' || is_null($attributes['ranking_name'])
-                ? $artist->artist_name.' List'
+                ? $rankedArtist->artist_name.' List'
                 : $attributes['ranking_name'];
 
             /* create a new ranking */
             $ranking = Ranking::create([
-                'artist_id' => $artist->getKey(),
+                'artist_id' => $rankedArtist->getKey(),
                 'user_id' => $user->getKey(),
                 'name' => Str::limit($name, 30),
                 'is_public' => $attributes['is_public'] ?? false,
@@ -43,16 +42,16 @@ final class StoreArtistRanking
 
             $tracks = collect($attributes['tracks']);
 
-            $artists = $this->resolveArtists($tracks);
+            $featuredArtists = $this->resolveFeaturedArtists($tracks);
 
-            $songs = $tracks->map(function ($song) use ($ranking, $artist, $artists) {
+            $songs = $tracks->map(function ($song) use ($ranking, $rankedArtist, $featuredArtists) {
                 $isFeaturedTrack = $song['featured_artist'] ?? false;
 
                 return [
                     'ranking_id' => $ranking->getKey(),
                     'artist_id' => $isFeaturedTrack
-                        ? $artists->get($song['primary_artist']['id'])
-                        : $artist->getKey(),
+                        ? $featuredArtists->get($song['primary_artist']['id'])
+                        : $rankedArtist->getKey(),
                     'spotify_song_id' => $song['id'],
                     'uuid' => $song['uuid'],
                     'title' => $song['name'] ?? 'Track deleted from spotify servers.',
@@ -70,11 +69,21 @@ final class StoreArtistRanking
         });
     }
 
-    private function resolveArtists(Collection $tracks): Collection
+    /**
+     * "appears on" tracks belong to their primary artist, so those records need to exist.
+     * They arrive without artwork; UpdateArtistImages backfills it.
+     *
+     * Covers the featured tracks only — songs the ranked artist owns are not in here.
+     *
+     * @param  Collection<int, array{featured_artist?: bool, primary_artist?: array{id: string, name: string}}>  $tracks
+     * @return Collection<string, int> spotify artist id => artists.id, empty when nothing is featured
+     */
+    private function resolveFeaturedArtists(Collection $tracks): Collection
     {
         $primaryTrackArtists = $tracks
             ->filter(fn (array $song) => $song['featured_artist'] ?? false)
             ->pluck('primary_artist')
+            ->filter()
             ->unique('id')
             ->values();
 
@@ -82,16 +91,16 @@ final class StoreArtistRanking
             return collect();
         }
 
-        $keys = Artist::query()
+        $artists = Artist::query()
             ->whereIn('artist_id', $primaryTrackArtists->pluck('id'))
             ->pluck('id', 'artist_id');
 
         /* Insert the ones we've never seen, in a single query. Upserting the whole set instead
            would burn an auto-increment id for every row that already existed. */
-        $newArtists = $primaryTrackArtists->reject(fn (array $primary) => $keys->has($primary['id']));
+        $newArtists = $primaryTrackArtists->reject(fn (array $primary) => $artists->has($primary['id']));
 
         if ($newArtists->isEmpty()) {
-            return $keys;
+            return $artists;
         }
 
         Artist::insertOrIgnore($newArtists->map(fn (array $primary) => [
@@ -101,7 +110,7 @@ final class StoreArtistRanking
             'updated_at' => now(),
         ])->all());
 
-        return $keys->merge(
+        return $artists->merge(
             Artist::query()
                 ->whereIn('artist_id', $newArtists->pluck('id'))
                 ->pluck('id', 'artist_id')

--- a/app/Actions/Rankings/StorePlaylistRanking.php
+++ b/app/Actions/Rankings/StorePlaylistRanking.php
@@ -64,6 +64,12 @@ final class StorePlaylistRanking
         });
     }
 
+    /**
+     * Make sure every artist the playlist references has a record.
+     *
+     * @param  Collection<int, array{artist_id: string, artist_name: string, is_podcast: bool}>  $tracks
+     * @return Collection<string, int> spotify artist id => artists.id
+     */
     private function resolveArtists(Collection $tracks): Collection
     {
         $trackArtists = $tracks->unique('artist_id')->values();

--- a/app/Actions/Rankings/StorePlaylistRanking.php
+++ b/app/Actions/Rankings/StorePlaylistRanking.php
@@ -7,6 +7,7 @@ use App\Models\Playlist;
 use App\Models\Ranking;
 use App\Models\Song;
 use App\Models\User;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
@@ -43,30 +44,11 @@ final class StorePlaylistRanking
 
             $tracks = collect($attributes['tracks']);
 
-            // Upsert all unique artists in one query
-            $uniqueArtists = $tracks
-                ->unique('artist_id')
-                ->map(fn ($track) => [
-                    'artist_id' => $track['artist_id'],
-                    'artist_name' => $track['artist_name'],
-                    'is_podcast' => $track['is_podcast'],
-                    'created_at' => now(),
-                    'updated_at' => now(),
-                ])
-                ->values()
-                ->toArray();
-
-            Artist::upsert($uniqueArtists, ['artist_id'], ['artist_name', 'is_podcast', 'updated_at']);
-
-            // Fetch all artists we need in one query
-            $artists = Artist::query()
-                ->whereIn('artist_id', $tracks->pluck('artist_id')->unique())
-                ->get()
-                ->keyBy('artist_id');
+            $artists = $this->resolveArtists($tracks);
 
             // Map songs with artist IDs
             $songs = $tracks->map(fn ($track) => [
-                'artist_id' => $artists->get($track['artist_id'])?->getKey(),
+                'artist_id' => $artists->get($track['artist_id']),
                 'ranking_id' => $ranking->getKey(),
                 'spotify_song_id' => $track['id'],
                 'uuid' => $track['uuid'],
@@ -80,5 +62,36 @@ final class StorePlaylistRanking
 
             return $ranking;
         });
+    }
+
+    private function resolveArtists(Collection $tracks): Collection
+    {
+        $trackArtists = $tracks->unique('artist_id')->values();
+
+        $artists = Artist::query()
+            ->whereIn('artist_id', $trackArtists->pluck('artist_id'))
+            ->pluck('id', 'artist_id');
+
+        /* Insert the ones we've never seen, in a single query. Upserting the whole set instead
+           would burn an auto-increment id for every row that already existed. */
+        $newArtists = $trackArtists->reject(fn (array $track) => $artists->has($track['artist_id']));
+
+        if ($newArtists->isEmpty()) {
+            return $artists;
+        }
+
+        Artist::insertOrIgnore($newArtists->map(fn (array $track) => [
+            'artist_id' => $track['artist_id'],
+            'artist_name' => $track['artist_name'],
+            'is_podcast' => $track['is_podcast'],
+            'created_at' => now(),
+            'updated_at' => now(),
+        ])->all());
+
+        return $artists->merge(
+            Artist::query()
+                ->whereIn('artist_id', $newArtists->pluck('artist_id'))
+                ->pluck('id', 'artist_id')
+        );
     }
 }

--- a/app/Console/Commands/UpdateArtistImages.php
+++ b/app/Console/Commands/UpdateArtistImages.php
@@ -85,7 +85,7 @@ class UpdateArtistImages extends Command
 
             return $success;
         } catch (Exception) {
-            Log::channel('discord_other_updates')->error('Could not authenticate with spotify for updating artist images.');
+            Log::channel('discord_other_updates')->error('Could not authenticate with spotify for updating artist images. Make sure SOP token is refreshed.');
 
             return false;
         }

--- a/app/Console/Commands/UpdateArtistImages.php
+++ b/app/Console/Commands/UpdateArtistImages.php
@@ -18,6 +18,8 @@ class UpdateArtistImages extends Command
 
     protected $description = 'Update Artist Profile Images';
 
+    private int $updated = 0;
+
     public function handle()
     {
         $loggedIn = $this->login();
@@ -26,31 +28,46 @@ class UpdateArtistImages extends Command
             return Command::FAILURE;
         }
 
-        /* Loop through every artist in chunks of 50 and attempt to update their image. */
-        Artist::query()->chunk(50, function ($chunk) {
-            $ids = $chunk->pluck('artist_id')->implode(',');
+        Artist::query()
+            ->chunk(50, function ($chunk) {
+                $ids = $chunk->pluck('artist_id')->implode(',');
 
-            $response = Http::withToken(Auth::user()->external_token)
-                ->get("https://api.spotify.com/v1/artists?ids={$ids}");
+                $response = Http::withToken(Auth::user()->external_token)
+                    ->get("https://api.spotify.com/v1/artists?ids={$ids}");
 
-            $upserts = collect($response->json('artists'))
-                ->filter()
-                ->map(fn ($artist) => [
-                    'artist_id' => $artist['id'],
-                    'artist_name' => $artist['name'],
-                    'artist_img' => data_get($artist, 'images.0.url'),
-                ])
-                ->all();
+                $artists = collect($response->json('artists'))
+                    ->filter()
+                    ->keyBy('id');
 
-            if ($upserts) {
-                Artist::query()->upsert($upserts, ['artist_id'], ['artist_name', 'artist_img']);
-            }
-        });
+                $chunk->each(function (Artist $artist) use ($artists) {
+                    $data = $artists->get($artist->artist_id);
+
+                    if (! $data) {
+                        return;
+                    }
+
+                    $image = data_get($data, 'images.0.url');
+
+                    /* spotify hands back the same artwork on almost every run */
+                    if ($artist->artist_img === $image) {
+                        return;
+                    }
+
+                    $artist->update([
+                        'artist_name' => $data['name'],
+                        'artist_img' => $image,
+                    ]);
+
+                    $this->updated++;
+                });
+            });
 
         Auth::logout();
 
         Session::invalidate();
         Session::regenerateToken();
+
+        Log::channel('discord_other_updates')->info("Updated {$this->updated} artist images.");
 
         return Command::SUCCESS;
     }

--- a/database/migrations/2026_08_03_193409_compact_artist_ids.php
+++ b/database/migrations/2026_08_03_193409_compact_artist_ids.php
@@ -1,0 +1,123 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        /* Only MySQL burns ids this way, and the statements below are MySQL-only syntax.
+           The test suite runs on SQLite, where this would fail outright. */
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        if (DB::table('artists')->count() === 0) {
+            return;
+        }
+
+        $this->severDanglingReferences();
+        $this->buildIdMap();
+        $this->repointChildren();
+        $this->rewriteArtistTable();
+
+        DB::statement('DROP TABLE `artist_id_map`');
+    }
+
+    public function down(): void
+    {
+        throw new RuntimeException('compact_artist_ids cannot be reversed; the previous artist ids are not recoverable.');
+    }
+
+    /**
+     * Null out child rows pointing at an artist that no longer exists. They are already
+     * broken, and left alone the renumbering would silently attach them to whichever
+     * artist inherits that id.
+     */
+    private function severDanglingReferences(): void
+    {
+        foreach (['songs', 'rankings'] as $table) {
+            DB::table($table)
+                ->whereNotNull('artist_id')
+                ->whereNotIn('artist_id', fn ($query) => $query->select('id')->from('artists'))
+                ->update(['artist_id' => null]);
+        }
+    }
+
+    /**
+     * Map every existing id to its position in the sequence. Ordering by the current id
+     * keeps the relative order of the table intact.
+     */
+    private function buildIdMap(): void
+    {
+        DB::statement('DROP TABLE IF EXISTS `artist_id_map`');
+
+        DB::statement('
+            CREATE TABLE `artist_id_map` (
+                `old_id` BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+                `new_id` BIGINT UNSIGNED NOT NULL,
+                UNIQUE KEY `artist_id_map_new_id_unique` (`new_id`)
+            )
+        ');
+
+        DB::statement('
+            INSERT INTO `artist_id_map` (`old_id`, `new_id`)
+            SELECT `id`, ROW_NUMBER() OVER (ORDER BY `id`) FROM `artists`
+        ');
+    }
+
+    /**
+     * These are plain foreign key columns with no uniqueness of their own, so they can be
+     * rewritten in place with a join.
+     */
+    private function repointChildren(): void
+    {
+        DB::transaction(function () {
+            foreach (['songs', 'rankings'] as $table) {
+                DB::statement("
+                    UPDATE `{$table}` AS child
+                    JOIN `artist_id_map` AS map ON map.`old_id` = child.`artist_id`
+                    SET child.`artist_id` = map.`new_id`
+                ");
+            }
+        });
+    }
+
+    /**
+     * Rebuild the table rather than updating ids in place. Rewriting a primary key row by
+     * row risks colliding with an id the scan has not reached yet; copying into a fresh
+     * table and swapping it in sidesteps that entirely.
+     */
+    private function rewriteArtistTable(): void
+    {
+        $columns = collect(Schema::getColumnListing('artists'));
+
+        $target = $columns->map(fn (string $column) => "`{$column}`")->implode(', ');
+
+        $source = $columns
+            ->map(fn (string $column) => $column === 'id' ? 'map.`new_id`' : "artists.`{$column}`")
+            ->implode(', ');
+
+        DB::statement('DROP TABLE IF EXISTS `artists_renumbered`');
+        DB::statement('CREATE TABLE `artists_renumbered` LIKE `artists`');
+
+        DB::statement("
+            INSERT INTO `artists_renumbered` ({$target})
+            SELECT {$source}
+            FROM `artists`
+            JOIN `artist_id_map` AS map ON map.`old_id` = artists.`id`
+        ");
+
+        $suffix = Str::random(8);
+
+        DB::statement("RENAME TABLE `artists` TO `artists_old_{$suffix}`, `artists_renumbered` TO `artists`");
+        DB::statement("DROP TABLE `artists_old_{$suffix}`");
+
+        $next = DB::table('artists')->max('id') + 1;
+
+        DB::statement("ALTER TABLE `artists` AUTO_INCREMENT = {$next}");
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -3,15 +3,13 @@
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schedule;
 use Spatie\Health\Commands\ScheduleCheckHeartbeatCommand;
+use Spatie\Health\Models\HealthCheckResultHistoryItem;
 
 Schedule::command('artists:update-images')
     ->timezone('America/New_York')
     ->dailyAt('08:00') /* daily at 8am */
-    ->onSuccess(function () {
-        Log::channel('discord_other_updates')->info('Artist Images updated successfully.');
-    })
     ->onFailure(function () {
-        Log::channel('discord_other_updates')->info('Something went wrong updating artist images.');
+        Log::channel('discord_other_updates')->info('Something went wrong updating artist images. You may need to refresh SOP token.');
     });
 
 Schedule::command('daily-digest:send')
@@ -34,6 +32,6 @@ Schedule::command('newsletter:send')
 Schedule::command(ScheduleCheckHeartbeatCommand::class)->everyMinute();
 Schedule::command('model:prune', [
     '--model' => [
-        \Spatie\Health\Models\HealthCheckResultHistoryItem::class,
+        HealthCheckResultHistoryItem::class,
     ],
 ])->daily();

--- a/tests/Feature/Rankings/RankingCreationTest.php
+++ b/tests/Feature/Rankings/RankingCreationTest.php
@@ -136,6 +136,10 @@ describe('creating rankings', function () {
 
         expect($ranking)->not->toBeNull();
         expect($ranking->songs()->count())->toBe(3);
+
+        $localNatives = Artist::where('artist_id', 'local-natives-id')->firstOrFail();
+
+        expect($ranking->songs()->pluck('artist_id')->unique()->all())->toBe([$localNatives->getKey()]);
     });
 
     test('can create a ranking for a show', function () {


### PR DESCRIPTION
- pulls artist handling for store ranking actions into helper funcs to help aid clarity.
- migration to fix the bug around upserting artist images. scary migration. tested locally with copy of prod
- fix cache clear
- updated test assertion
- fixed update artist images command