### PR TITLE
improvement: polymorphic ranking type.

### DIFF
--- a/app/Actions/Rankings/StoreArtistRanking.php
+++ b/app/Actions/Rankings/StoreArtistRanking.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Rankings;
 
+use App\Enums\RankingType;
 use App\Models\Artist;
 use App\Models\Ranking;
 use App\Models\Song;
@@ -29,7 +30,8 @@ final class StoreArtistRanking
 
             /* create a new ranking */
             $ranking = Ranking::create([
-                'artist_id' => $rankedArtist->getKey(),
+                'type' => RankingType::ARTIST->value,
+                'source_id' => $rankedArtist->getKey(),
                 'user_id' => $user->getKey(),
                 'name' => Str::limit($name, 30),
                 'is_public' => $attributes['is_public'] ?? false,

--- a/app/Actions/Rankings/StorePlaylistRanking.php
+++ b/app/Actions/Rankings/StorePlaylistRanking.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Rankings;
 
+use App\Enums\RankingType;
 use App\Models\Artist;
 use App\Models\Playlist;
 use App\Models\Ranking;
@@ -32,7 +33,8 @@ final class StorePlaylistRanking
                 : $attributes['ranking_name'];
 
             $ranking = Ranking::create([
-                'playlist_id' => $playlist->getKey(),
+                'type' => RankingType::PLAYLIST->value,
+                'source_id' => $playlist->getKey(),
                 'user_id' => $user->getKey(),
                 'name' => Str::limit($name, 30),
                 'is_public' => $attributes['is_public'] ?? false,

--- a/app/Actions/Rankings/StoreShowRanking.php
+++ b/app/Actions/Rankings/StoreShowRanking.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Rankings;
 
+use App\Enums\RankingType;
 use App\Models\Artist;
 use App\Models\Ranking;
 use App\Models\Show;
@@ -39,7 +40,8 @@ final class StoreShowRanking
                 : $attributes['ranking_name'];
 
             $ranking = Ranking::create([
-                'show_id' => $show->getKey(),
+                'type' => RankingType::SHOW->value,
+                'source_id' => $show->getKey(),
                 'user_id' => $user->getKey(),
                 'name' => Str::limit($name, 30),
                 'is_public' => $attributes['is_public'] ?? false,

--- a/app/Enums/RankingType.php
+++ b/app/Enums/RankingType.php
@@ -35,6 +35,15 @@ enum RankingType: string
         };
     }
 
+    public function filamentColor(): string
+    {
+        return match ($this) {
+            self::ARTIST => 'primary',
+            self::PLAYLIST => 'success',
+            self::SHOW => 'info',
+        };
+    }
+
     public function itemLabel(): string
     {
         return match ($this) {

--- a/app/Filament/Concerns/HasDateFilters.php
+++ b/app/Filament/Concerns/HasDateFilters.php
@@ -33,7 +33,10 @@ trait HasDateFilters
     protected bool $hasDeferredFilters = true;
 
     /** Polling re-renders the widget, which closes the filter popover mid-use. */
-    protected ?string $pollingInterval = null;
+    protected function getPollingInterval(): ?string
+    {
+        return null;
+    }
 
     public function filtersSchema(Schema $schema): Schema
     {

--- a/app/Filament/Resources/Rankings/RankingResource.php
+++ b/app/Filament/Resources/Rankings/RankingResource.php
@@ -104,34 +104,34 @@ class RankingResource extends Resource
                 Section::make('Artist Details')
                     ->visible(fn (Ranking $record): bool => $record->type === RankingType::ARTIST)
                     ->schema([
-                        TextEntry::make('artist.artist_name')
+                        TextEntry::make('source.artist_name')
                             ->label('Artist Name')
                             ->icon(Heroicon::MusicalNote),
-                        TextEntry::make('artist.artist_id')
+                        TextEntry::make('source.artist_id')
                             ->label('Spotify ID'),
                     ]),
 
                 Section::make('Playlist Details')
                     ->visible(fn (Ranking $record): bool => $record->type === RankingType::PLAYLIST)
                     ->schema([
-                        TextEntry::make('playlist.name')
+                        TextEntry::make('source.name')
                             ->label('Playlist Name'),
-                        TextEntry::make('playlist.description')
+                        TextEntry::make('source.description')
                             ->label('Playlist Description'),
-                        TextEntry::make('playlist.track_count')
+                        TextEntry::make('source.track_count')
                             ->label('Tracks in Playlist'),
                     ]),
 
                 Section::make('Show Details')
                     ->visible(fn (Ranking $record): bool => $record->type === RankingType::SHOW)
                     ->schema([
-                        TextEntry::make('show.name')
+                        TextEntry::make('source.name')
                             ->label('Show Name'),
-                        TextEntry::make('show.publisher')
+                        TextEntry::make('source.publisher')
                             ->label('Publisher'),
-                        TextEntry::make('show.description')
+                        TextEntry::make('source.description')
                             ->label('Description'),
-                        TextEntry::make('show.episode_count')
+                        TextEntry::make('source.episode_count')
                             ->label('Total Episodes'),
                     ]),
             ]);

--- a/app/Filament/Resources/Rankings/Tables/RankingTable.php
+++ b/app/Filament/Resources/Rankings/Tables/RankingTable.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\Rankings\Tables;
 
 use App\Models\Ranking;
+use App\QueryBuilders\RankingQueryBuilder;
 use Carbon\Carbon;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
@@ -34,15 +35,16 @@ class RankingTable
             TextColumn::make('name')
                 ->searchable()
                 ->sortable(),
-            TextColumn::make('artist.artist_name')
-                ->label('Artist')
-                ->searchable()
-                ->sortable()
+            TextColumn::make('type')
+                ->label('Type')
+                ->badge()
+                ->state(fn (Ranking $record): string => $record->type->label())
+                ->color(fn (Ranking $record): string => $record->type->filamentColor())
                 ->toggleable(isToggledHiddenByDefault: false),
-            TextColumn::make('playlist.name')
-                ->label('Playlist')
-                ->searchable()
-                ->sortable()
+            TextColumn::make('source')
+                ->label('Source')
+                ->state(fn (Ranking $record): ?string => $record->source?->name())
+                ->searchable(query: fn (RankingQueryBuilder $query, string $search) => $query->whereSourceNameLike($search))
                 ->toggleable(isToggledHiddenByDefault: false),
             IconColumn::make('is_ranked')
                 ->label('Is Ranked')

--- a/app/Jobs/DeleteUserJob.php
+++ b/app/Jobs/DeleteUserJob.php
@@ -23,7 +23,7 @@ class DeleteUserJob implements ShouldQueue
         /* Get the user's rankings. */
         $rankings = $this->user
             ->rankings()
-            ->with('songs', 'artist')
+            ->with('songs', 'source')
             ->get();
 
         /* Send the user their data. */

--- a/app/Livewire/Dashboard/InProcessRankings.php
+++ b/app/Livewire/Dashboard/InProcessRankings.php
@@ -14,7 +14,7 @@ class InProcessRankings extends Component
             'rankings' => Ranking::query()
                 ->where('user_id', Auth::id())
                 ->where('is_ranked', false)
-                ->with(['artist', 'user'])
+                ->with(['source', 'user'])
                 ->with('songs', fn ($q) => $q->where('rank', 1))
                 ->withCount('songs')
                 ->get(),

--- a/app/Livewire/Profile/Settings.php
+++ b/app/Livewire/Profile/Settings.php
@@ -60,7 +60,7 @@ class Settings extends Component
     {
         $rankings = Ranking::query()
             ->where('user_id', Auth::id())
-            ->with('songs', 'artist')
+            ->with('songs', 'source')
             ->get();
 
         $user = Auth::user();

--- a/app/Livewire/Ranking/Ranking.php
+++ b/app/Livewire/Ranking/Ranking.php
@@ -14,7 +14,7 @@ class Ranking extends Component
     public function mount($id)
     {
         $this->ranking = RankingModel::query()
-            ->with(['user', 'songs', 'artist', 'sortingState'])
+            ->with(['user', 'songs', 'source', 'sortingState'])
             ->find($id);
 
         if (is_null($this->ranking)) {

--- a/app/Models/Artist.php
+++ b/app/Models/Artist.php
@@ -6,7 +6,7 @@ use App\Contracts\Rankable;
 use App\QueryBuilders\ArtistQueryBuilder;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
-use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 #[UseEloquentBuilder(ArtistQueryBuilder::class)]
 class Artist extends Model implements Rankable
@@ -32,9 +32,9 @@ class Artist extends Model implements Rankable
         ];
     }
 
-    public function rankings(): HasMany
+    public function rankings(): MorphMany
     {
-        return $this->hasMany(Ranking::class);
+        return $this->morphMany(Ranking::class, 'source', 'type', 'source_id');
     }
 
     public function cover(): ?string

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -6,7 +6,7 @@ use App\Contracts\Rankable;
 use App\QueryBuilders\PlaylistQueryBuilder;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 #[UseEloquentBuilder(PlaylistQueryBuilder::class)]
 class Playlist extends Model implements Rankable
@@ -28,9 +28,9 @@ class Playlist extends Model implements Rankable
         ];
     }
 
-    public function rankings(): HasMany
+    public function rankings(): MorphMany
     {
-        return $this->hasMany(Ranking::class);
+        return $this->morphMany(Ranking::class, 'source', 'type', 'source_id');
     }
 
     public function user(): BelongsTo

--- a/app/Models/Ranking.php
+++ b/app/Models/Ranking.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use App\Contracts\Rankable;
 use App\Enums\RankingType;
 use App\QueryBuilders\RankingQueryBuilder;
 use Carbon\Carbon;
@@ -10,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Facades\Auth;
 use Kyledoesdev\Essentials\Concerns\HasStatsAfterEvents;
 use Spatie\Comments\Models\Concerns\HasComments;
@@ -24,9 +24,8 @@ class Ranking extends Model
 
     protected $fillable = [
         'user_id',
-        'artist_id',
-        'playlist_id',
-        'show_id',
+        'type',
+        'source_id',
         'name',
         'is_ranked',
         'is_public',
@@ -38,6 +37,7 @@ class Ranking extends Model
     protected function casts(): array
     {
         return [
+            'type' => RankingType::class,
             'is_ranked' => 'boolean',
             'is_public' => 'boolean',
             'has_podcast_episode' => 'boolean',
@@ -53,19 +53,9 @@ class Ranking extends Model
         return $this->belongsTo(User::class);
     }
 
-    public function artist(): BelongsTo
+    public function source(): MorphTo
     {
-        return $this->belongsTo(Artist::class);
-    }
-
-    public function playlist(): BelongsTo
-    {
-        return $this->belongsTo(Playlist::class);
-    }
-
-    public function show(): BelongsTo
-    {
-        return $this->belongsTo(Show::class);
+        return $this->morphTo('source', 'type', 'source_id');
     }
 
     public function songs(): HasMany
@@ -98,15 +88,6 @@ class Ranking extends Model
         return Carbon::parse($this->attributes['completed_at'])->inUserTimezone()->format('M d, Y g:i A T');
     }
 
-    public function getTypeAttribute(): RankingType
-    {
-        return match (true) {
-            ! is_null($this->show_id) => RankingType::SHOW,
-            ! is_null($this->playlist_id) => RankingType::PLAYLIST,
-            default => RankingType::ARTIST,
-        };
-    }
-
     public function isPlaylistType(): bool
     {
         return $this->type === RankingType::PLAYLIST;
@@ -115,15 +96,6 @@ class Ranking extends Model
     public function isShowType(): bool
     {
         return $this->type === RankingType::SHOW;
-    }
-
-    public function getSourceAttribute(): Rankable
-    {
-        return match ($this->type) {
-            RankingType::SHOW => $this->show,
-            RankingType::PLAYLIST => $this->playlist,
-            RankingType::ARTIST => $this->artist,
-        };
     }
 
     /* Helpers */

--- a/app/Models/Show.php
+++ b/app/Models/Show.php
@@ -3,7 +3,7 @@
 namespace App\Models;
 
 use App\Contracts\Rankable;
-use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 class Show extends Model implements Rankable
 {
@@ -25,9 +25,9 @@ class Show extends Model implements Rankable
         ];
     }
 
-    public function rankings(): HasMany
+    public function rankings(): MorphMany
     {
-        return $this->hasMany(Ranking::class);
+        return $this->morphMany(Ranking::class, 'source', 'type', 'source_id');
     }
 
     public function getDescriptionAttribute($value): ?string

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,12 +2,16 @@
 
 namespace App\Providers;
 
+use App\Enums\RankingType;
+use App\Models\Artist;
+use App\Models\Playlist;
+use App\Models\Show;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Str;
 use SocialiteProviders\Manager\SocialiteWasCalled;
 use SocialiteProviders\Spotify\Provider;
 use Spatie\Health\Checks\Checks\DatabaseCheck;
@@ -53,6 +57,12 @@ class AppServiceProvider extends ServiceProvider
             UsedDiskSpaceCheck::new()
                 ->warnWhenUsedSpaceIsAbovePercentage(90)
                 ->failWhenUsedSpaceIsAbovePercentage(95),
+        ]);
+
+        Relation::morphMap([
+            RankingType::ARTIST->value => Artist::class,
+            RankingType::PLAYLIST->value => Playlist::class,
+            RankingType::SHOW->value => Show::class,
         ]);
     }
 }

--- a/app/QueryBuilders/ArtistQueryBuilder.php
+++ b/app/QueryBuilders/ArtistQueryBuilder.php
@@ -2,6 +2,7 @@
 
 namespace App\QueryBuilders;
 
+use App\Enums\RankingType;
 use Illuminate\Database\Eloquent\Builder;
 
 class ArtistQueryBuilder extends Builder
@@ -10,20 +11,21 @@ class ArtistQueryBuilder extends Builder
     {
         return $this->newQuery()
             ->selectRaw('
-                count(rankings.artist_id) as artist_rankings_count,
+                count(rankings.source_id) as artist_rankings_count,
                 artists.id,
                 artists.artist_id,
                 artists.artist_name,
                 artists.artist_img
             ')
             ->join('rankings', function ($join) {
-                $join->on('rankings.artist_id', '=', 'artists.id')
+                $join->on('rankings.source_id', '=', 'artists.id')
+                    ->where('rankings.type', RankingType::ARTIST->value)
                     ->whereNull('rankings.deleted_at')
                     ->where('rankings.is_ranked', true)
                     ->where('rankings.is_public', true);
             })
             ->whereNotNull('artists.artist_img')
-            ->groupBy('rankings.artist_id')
+            ->groupBy('rankings.source_id')
             ->orderBy('artist_rankings_count', 'desc')
             ->orderBy('artists.artist_name', 'asc')
             ->limit($limit);

--- a/app/QueryBuilders/PlaylistQueryBuilder.php
+++ b/app/QueryBuilders/PlaylistQueryBuilder.php
@@ -2,6 +2,7 @@
 
 namespace App\QueryBuilders;
 
+use App\Enums\RankingType;
 use Illuminate\Database\Eloquent\Builder;
 
 class PlaylistQueryBuilder extends Builder
@@ -10,7 +11,7 @@ class PlaylistQueryBuilder extends Builder
     {
         return $this->newQuery()
             ->selectRaw('
-                count(rankings.playlist_id) as playlist_rankings_count,
+                count(rankings.source_id) as playlist_rankings_count,
                 playlists.id,
                 playlists.playlist_id,
                 playlists.name,
@@ -18,12 +19,13 @@ class PlaylistQueryBuilder extends Builder
                 playlists.creator_name
             ')
             ->join('rankings', function ($join) {
-                $join->on('rankings.playlist_id', '=', 'playlists.id')
+                $join->on('rankings.source_id', '=', 'playlists.id')
+                    ->where('rankings.type', RankingType::PLAYLIST->value)
                     ->whereNull('rankings.deleted_at')
                     ->where('rankings.is_ranked', true)
                     ->where('rankings.is_public', true);
             })
-            ->groupBy('rankings.playlist_id')
+            ->groupBy('rankings.source_id')
             ->orderBy('playlist_rankings_count', 'desc')
             ->orderBy('playlists.name', 'asc');
     }

--- a/app/QueryBuilders/RankingQueryBuilder.php
+++ b/app/QueryBuilders/RankingQueryBuilder.php
@@ -2,6 +2,10 @@
 
 namespace App\QueryBuilders;
 
+use App\Enums\RankingType;
+use App\Models\Artist;
+use App\Models\Playlist;
+use App\Models\Show;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
@@ -13,27 +17,9 @@ class RankingQueryBuilder extends Builder
         return $this->newQuery()
             ->public()
             ->completed()
-            ->when($search, function (Builder $query, string $search) {
-                $query->where(fn (Builder $query) => $query
-                    ->whereIn('artist_id', fn ($q) => $q
-                        ->select('id')
-                        ->from('artists')
-                        ->where('artist_name', 'LIKE', "%{$search}%")
-                    )
-                    ->orWhereIn('playlist_id', fn ($q) => $q
-                        ->select('id')
-                        ->from('playlists')
-                        ->where('name', 'LIKE', "%{$search}%")
-                    )
-                    ->orWhereIn('show_id', fn ($q) => $q
-                        ->select('id')
-                        ->from('shows')
-                        ->where('name', 'LIKE', "%{$search}%")
-                    )
-                );
-            })
+            ->when($search, fn (Builder $query, string $search) => $query->whereSourceNameLike($search))
             ->withHasPodcastEpisode()
-            ->with('user', 'artist', 'playlist', 'show')
+            ->with('user', 'source')
             ->with('songs', fn ($query) => $query->where('rank', 1))
             ->withCount('songs')
             ->orderBy('completed_at', 'desc');
@@ -45,7 +31,7 @@ class RankingQueryBuilder extends Builder
             ->where('user_id', $user ? $user->getKey() : Auth::id())
             ->when($user && $user->getKey() !== Auth::id(), fn (Builder $query) => $query->public()->completed())
             ->withHasPodcastEpisode()
-            ->with('user', 'artist', 'playlist', 'show')
+            ->with('user', 'source')
             ->with('songs', fn ($query) => $query->with('artist'))
             ->withCount('songs')
             ->orderByRaw('completed_at IS NULL DESC, completed_at DESC');
@@ -58,7 +44,7 @@ class RankingQueryBuilder extends Builder
             ->completed()
             ->whereBetween('completed_at', [now()->subMonth(), now()])
             ->withHasPodcastEpisode()
-            ->with('user', 'artist')
+            ->with('user', 'source')
             ->with('songs', fn ($query) => $query->where('rank', 1))
             ->withCount('songs')
             ->orderBy('completed_at', 'desc');
@@ -71,7 +57,7 @@ class RankingQueryBuilder extends Builder
             ->completed()
             ->has('songs', '<=', 500)
             ->withCount('songs')
-            ->with('user', 'artist', 'playlist', 'show')
+            ->with('user', 'source')
             ->orderByDesc('songs_count')
             ->orderBy('name')
             ->limit($limit);
@@ -87,16 +73,27 @@ class RankingQueryBuilder extends Builder
         return $this->newQuery()->public()->completed()->count();
     }
 
+    public function whereSourceNameLike(string $search): static
+    {
+        return $this->whereHasMorph('source', [Artist::class, Playlist::class, Show::class],
+            fn (Builder $query, string $type) => $query->where(
+                $type === Artist::class ? 'artist_name' : 'name',
+                'LIKE',
+                "%{$search}%",
+            ),
+        );
+    }
+
     public function withHasPodcastEpisode()
     {
         return $this->addSelect([
             'has_podcast_episode' => function ($q) {
-                $q->selectRaw('CASE WHEN rankings.show_id IS NOT NULL OR EXISTS (
+                $q->selectRaw('CASE WHEN rankings.type = ? OR EXISTS (
                     SELECT 1 FROM songs
                     INNER JOIN artists ON songs.artist_id = artists.id
                     WHERE songs.ranking_id = rankings.id
                     AND artists.is_podcast = 1
-                ) THEN 1 ELSE 0 END');
+                ) THEN 1 ELSE 0 END', [RankingType::SHOW->value]);
             },
         ]);
     }

--- a/app/QueryBuilders/SongQueryBuilder.php
+++ b/app/QueryBuilders/SongQueryBuilder.php
@@ -2,6 +2,7 @@
 
 namespace App\QueryBuilders;
 
+use App\Enums\RankingType;
 use Illuminate\Database\Eloquent\Builder;
 
 class SongQueryBuilder extends Builder
@@ -9,7 +10,7 @@ class SongQueryBuilder extends Builder
     public function rankedArtistCount(): int
     {
         return (int) (round($this->newQuery()
-            ->whereHas('ranking', fn (Builder $query) => $query->completed()->whereNull('playlist_id')->whereNull('show_id'))
+            ->whereHas('ranking', fn (Builder $query) => $query->completed()->where('type', RankingType::ARTIST->value))
             ->where('featured_artist', false)
             ->distinct('artist_id')
             ->count() / 25) * 25);

--- a/database/factories/RankingFactory.php
+++ b/database/factories/RankingFactory.php
@@ -2,8 +2,11 @@
 
 namespace Database\Factories;
 
+use App\Enums\RankingType;
 use App\Models\Artist;
+use App\Models\Playlist;
 use App\Models\Ranking;
+use App\Models\Show;
 use App\Models\Song;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -17,12 +20,28 @@ class RankingFactory extends Factory
     {
         return [
             'user_id' => User::factory(),
-            'artist_id' => Artist::factory(),
+            'type' => RankingType::ARTIST->value,
+            'source_id' => Artist::factory(),
             'name' => fake()->userName().' List',
             'is_ranked' => false,
             'is_public' => false,
             'completed_at' => null,
         ];
+    }
+
+    public function artist(?Artist $artist = null): static
+    {
+        return $this->for($artist ?? Artist::factory(), 'source');
+    }
+
+    public function playlist(?Playlist $playlist = null): static
+    {
+        return $this->for($playlist ?? Playlist::factory(), 'source');
+    }
+
+    public function show(?Show $show = null): static
+    {
+        return $this->for($show ?? Show::factory(), 'source');
     }
 
     public function configure()

--- a/database/factories/ShowFactory.php
+++ b/database/factories/ShowFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Show;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Show>
+ */
+class ShowFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'show_id' => str()->random(16),
+            'publisher' => fake()->company(),
+            'name' => fake()->sentence(1),
+            'description' => fake()->sentence(1),
+            'cover' => fake()->imageUrl(200, 200, 'show', true),
+            'episode_count' => rand(5, 100),
+            'data' => null,
+        ];
+    }
+}

--- a/database/migrations/2026_08_13_000000_convert_rankings_source_ids_to_polymorphic_source.php
+++ b/database/migrations/2026_08_13_000000_convert_rankings_source_ids_to_polymorphic_source.php
@@ -1,0 +1,83 @@
+<?php
+
+use App\Enums\RankingType;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('rankings', function (Blueprint $table) {
+            $table->unsignedBigInteger('source_id')->nullable()->after('user_id');
+            $table->string('type')->nullable()->after('source_id');
+        });
+
+        DB::transaction(function () {
+            $this->backfillSourceColumns();
+        });
+
+        Schema::table('rankings', function (Blueprint $table) {
+            $table->index(['type', 'source_id']);
+        });
+
+        Schema::table('rankings', function (Blueprint $table) {
+            $table->dropColumn(['artist_id', 'playlist_id', 'show_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('rankings', function (Blueprint $table) {
+            $table->unsignedBigInteger('artist_id')->nullable()->after('user_id');
+            $table->unsignedBigInteger('playlist_id')->nullable()->after('artist_id');
+            $table->unsignedBigInteger('show_id')->nullable()->after('playlist_id');
+        });
+
+        DB::transaction(function () {
+            foreach ($this->columnForType() as $type => $column) {
+                DB::table('rankings')
+                    ->where('type', $type)
+                    ->whereNotNull('source_id')
+                    ->update([$column => DB::raw('source_id')]);
+            }
+        });
+
+        Schema::table('rankings', function (Blueprint $table) {
+            $table->dropIndex(['type', 'source_id']);
+        });
+
+        Schema::table('rankings', function (Blueprint $table) {
+            $table->dropColumn(['type', 'source_id']);
+        });
+    }
+
+    private function columnForType(): array
+    {
+        return [
+            RankingType::SHOW->value => 'show_id',
+            RankingType::PLAYLIST->value => 'playlist_id',
+            RankingType::ARTIST->value => 'artist_id',
+        ];
+    }
+
+    private function backfillSourceColumns(): void
+    {
+        foreach ($this->columnForType() as $type => $column) {
+            DB::table('rankings')
+                ->whereNull('type')
+                ->whereNotNull($column)
+                ->update([
+                    'type' => $type,
+                    'source_id' => DB::raw($column),
+                ]);
+        }
+
+        /* A row with no source id at all read as an artist ranking before; keep it that way. */
+        DB::table('rankings')
+            ->whereNull('type')
+            ->update(['type' => RankingType::ARTIST->value]);
+    }
+};

--- a/resources/views/components/song-ranked-item.blade.php
+++ b/resources/views/components/song-ranked-item.blade.php
@@ -19,7 +19,7 @@
                 </h5>
                 @if ($song->featured_artist)
                     <p class="mx-2 mb-0.5 text-[10px] sm:text-xs text-zinc-500">
-                        (feat. {{ $ranking->artist?->artist_name }})
+                        (feat. {{ $ranking->source?->name() }})
                     </p>
                 @endif
                 @unless ($ranking->isShowType())

--- a/tests/Feature/Account/NotificationBellTest.php
+++ b/tests/Feature/Account/NotificationBellTest.php
@@ -115,7 +115,7 @@ describe('comment notification dispatch', function () {
 
 function commentableRanking(): Ranking
 {
-    return publicCompletedRanking(['comments_enabled' => true]);
+    return publicCompletedRanking(attributes: ['comments_enabled' => true]);
 }
 
 function createComment(User $commenter, Ranking $ranking, string $text = 'Great ranking!'): Comment

--- a/tests/Feature/Account/ProfilePageTest.php
+++ b/tests/Feature/Account/ProfilePageTest.php
@@ -9,7 +9,7 @@ describe('profile page', function () {
     test('shows the users completed public rankings', function () {
         $user = User::factory()->createOne();
 
-        $ranking = publicCompletedRanking(['user_id' => $user->getKey()]);
+        $ranking = publicCompletedRanking(attributes: ['user_id' => $user->getKey()]);
 
         actingAs($user)
             ->get(route('profile', ['id' => $user->spotify_id]))

--- a/tests/Feature/Discovery/ExplorePageTest.php
+++ b/tests/Feature/Discovery/ExplorePageTest.php
@@ -103,15 +103,9 @@ describe('searching', function () {
         $match = Artist::factory()->create(['artist_name' => 'Matching Artist']);
         $other = Artist::factory()->create(['artist_name' => 'Other Artist']);
 
-        $matchingRanking = publicCompletedRanking([
-            'artist_id' => $match->getKey(),
-            'name' => 'Matching Ranking',
-        ]);
+        $matchingRanking = publicCompletedRanking($match, ['name' => 'Matching Ranking']);
 
-        $otherRanking = publicCompletedRanking([
-            'artist_id' => $other->getKey(),
-            'name' => 'Other Ranking',
-        ]);
+        $otherRanking = publicCompletedRanking($other, ['name' => 'Other Ranking']);
 
         Livewire::test(Explorer::class)
             ->set('search', 'Matching Artist')
@@ -123,13 +117,9 @@ describe('searching', function () {
     test('can search rankings by playlist name', function () {
         $playlist = Playlist::factory()->create(['name' => 'Chill Vibes Playlist']);
 
-        $matchingRanking = publicCompletedRanking([
-            'artist_id' => null,
-            'playlist_id' => $playlist->getKey(),
-            'name' => 'Matching Playlist Ranking',
-        ]);
+        $matchingRanking = publicCompletedRanking($playlist, ['name' => 'Matching Playlist Ranking']);
 
-        $otherRanking = publicCompletedRanking(['name' => 'Other Ranking']);
+        $otherRanking = publicCompletedRanking(attributes: ['name' => 'Other Ranking']);
 
         Livewire::test(Explorer::class)
             ->set('search', 'Chill Vibes')
@@ -139,22 +129,11 @@ describe('searching', function () {
     });
 
     test('can search rankings by show name', function () {
-        $show = Show::create([
-            'show_id' => str()->random(16),
-            'publisher' => 'Podcast Publisher',
-            'name' => 'True Crime Weekly',
-            'description' => 'A weekly true crime show.',
-            'cover' => 'https://example.com/cover.jpg',
-            'episode_count' => 100,
-        ]);
+        $show = Show::factory()->createOne(['name' => 'True Crime Weekly']);
 
-        $matchingRanking = publicCompletedRanking([
-            'artist_id' => null,
-            'show_id' => $show->getKey(),
-            'name' => 'Matching Show Ranking',
-        ]);
+        $matchingRanking = publicCompletedRanking($show, ['name' => 'Matching Show Ranking']);
 
-        $otherRanking = publicCompletedRanking(['name' => 'Other Ranking']);
+        $otherRanking = publicCompletedRanking(attributes: ['name' => 'Other Ranking']);
 
         Livewire::test(Explorer::class)
             ->set('search', 'True Crime Weekly')

--- a/tests/Feature/Discovery/LeaderboardsPageTest.php
+++ b/tests/Feature/Discovery/LeaderboardsPageTest.php
@@ -34,8 +34,7 @@ describe('page access', function () {
         $artist = Artist::factory()->create(['artist_name' => 'Page Artist']);
         $user = User::factory()->createOne(['name' => 'Page Creator']);
 
-        publicCompletedRanking([
-            'artist_id' => $artist->getKey(),
+        publicCompletedRanking($artist, [
             'user_id' => $user->getKey(),
             'name' => 'Page Ranking',
         ]);
@@ -59,9 +58,9 @@ describe('top ranked artists', function () {
         $first = Artist::factory()->create(['artist_name' => 'First Artist']);
         $second = Artist::factory()->create(['artist_name' => 'Second Artist']);
 
-        publicCompletedRanking(['artist_id' => $first->getKey()]);
-        publicCompletedRanking(['artist_id' => $first->getKey()]);
-        publicCompletedRanking(['artist_id' => $second->getKey()]);
+        publicCompletedRanking($first);
+        publicCompletedRanking($first);
+        publicCompletedRanking($second);
 
         Livewire::test(Leaderboards::class)
             ->assertViewHas('topArtists', fn ($entries) => $entries->pluck('name')->all() === ['First Artist', 'Second Artist']
@@ -72,15 +71,13 @@ describe('top ranked artists', function () {
         $private = Artist::factory()->create(['artist_name' => 'Private Artist']);
         $unfinished = Artist::factory()->create(['artist_name' => 'Unfinished Artist']);
 
-        Ranking::factory()->create([
-            'artist_id' => $private->getKey(),
+        Ranking::factory()->artist($private)->create([
             'is_public' => false,
             'is_ranked' => true,
             'completed_at' => now(),
         ]);
 
-        Ranking::factory()->create([
-            'artist_id' => $unfinished->getKey(),
+        Ranking::factory()->artist($unfinished)->create([
             'is_public' => true,
             'is_ranked' => false,
             'completed_at' => null,
@@ -97,9 +94,9 @@ describe('top creators', function () {
         $casual = User::factory()->createOne(['name' => 'Casual Creator']);
         $private = User::factory()->createOne(['name' => 'Private Creator']);
 
-        publicCompletedRanking(['user_id' => $prolific->getKey()]);
-        publicCompletedRanking(['user_id' => $prolific->getKey()]);
-        publicCompletedRanking(['user_id' => $casual->getKey()]);
+        publicCompletedRanking(attributes: ['user_id' => $prolific->getKey()]);
+        publicCompletedRanking(attributes: ['user_id' => $prolific->getKey()]);
+        publicCompletedRanking(attributes: ['user_id' => $casual->getKey()]);
 
         Ranking::factory()->create([
             'user_id' => $private->getKey(),
@@ -116,7 +113,7 @@ describe('top creators', function () {
         foreach (range('a', 'k') as $letter) {
             $user = User::factory()->createOne(['name' => "creator-{$letter}"]);
 
-            publicCompletedRanking(['user_id' => $user->getKey()]);
+            publicCompletedRanking(attributes: ['user_id' => $user->getKey()]);
         }
 
         Livewire::test(Leaderboards::class)
@@ -130,16 +127,12 @@ describe('rankings with most songs', function () {
     test('rankings are ordered by song count and credit their creator', function () {
         $creator = User::factory()->createOne(['name' => 'List Maker']);
 
-        $bigger = publicCompletedRanking([
+        $bigger = publicCompletedRanking(attributes: [
             'user_id' => $creator->getKey(),
             'name' => 'Bigger Ranking',
         ]);
 
-        publicCompletedRanking([
-            'artist_id' => null,
-            'playlist_id' => Playlist::factory(),
-            'name' => 'Smaller Ranking',
-        ]);
+        publicCompletedRanking(Playlist::factory()->createOne(), ['name' => 'Smaller Ranking']);
 
         foreach (range(11, 15) as $rank) {
             Song::factory()->create([
@@ -156,22 +149,11 @@ describe('rankings with most songs', function () {
     });
 
     test('show rankings are included', function () {
-        $show = Show::create([
-            'show_id' => str()->random(16),
-            'publisher' => 'Podcast Publisher',
-            'name' => 'A Podcast Show',
-            'description' => 'A show about things.',
-            'cover' => 'https://example.com/cover.jpg',
-            'episode_count' => 100,
-        ]);
+        $show = Show::factory()->createOne(['name' => 'A Podcast Show']);
 
-        publicCompletedRanking([
-            'artist_id' => null,
-            'show_id' => $show->getKey(),
-            'name' => 'Show Ranking',
-        ]);
+        publicCompletedRanking($show, ['name' => 'Show Ranking']);
 
-        publicCompletedRanking(['name' => 'Music Ranking']);
+        publicCompletedRanking(attributes: ['name' => 'Music Ranking']);
 
         Livewire::test(Leaderboards::class)
             ->assertViewHas('biggestRankings', fn ($entries) => $entries->pluck('name')->all() === ['Music Ranking', 'Show Ranking']);
@@ -180,8 +162,8 @@ describe('rankings with most songs', function () {
     test('rankings with more than 500 songs are excluded', function () {
         $artist = Artist::factory()->create();
 
-        $within = publicCompletedRanking(['name' => 'Within Limit Ranking']);
-        $beyond = publicCompletedRanking(['name' => 'Beyond Limit Ranking']);
+        $within = publicCompletedRanking(attributes: ['name' => 'Within Limit Ranking']);
+        $beyond = publicCompletedRanking(attributes: ['name' => 'Beyond Limit Ranking']);
 
         Song::factory()->count(490)->create([
             'ranking_id' => $within->getKey(),

--- a/tests/Feature/Rankings/FeaturedTracksTest.php
+++ b/tests/Feature/Rankings/FeaturedTracksTest.php
@@ -114,7 +114,7 @@ describe('featured track storage', function () {
             ->call('beginRanking')
             ->assertHasNoErrors();
 
-        expect(Ranking::where('name', 'Test List')->firstOrFail()->artist->artist_id)->toBe('ranked-artist-id');
+        expect(Ranking::where('name', 'Test List')->firstOrFail()->source->artist_id)->toBe('ranked-artist-id');
     });
 });
 

--- a/tests/Feature/Rankings/RankingAlgorithmTest.php
+++ b/tests/Feature/Rankings/RankingAlgorithmTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\RankingType;
 use App\Livewire\SongRank\SongRankProcess;
 use App\Models\Artist;
 use App\Models\Ranking;
@@ -168,7 +169,8 @@ function algorithmRanking(User $user, string $name, array $expectedSongTitles): 
 
     $ranking = Ranking::create([
         'user_id' => $user->getKey(),
-        'artist_id' => $artist->getKey(),
+        'type' => RankingType::ARTIST->value,
+        'source_id' => $artist->getKey(),
         'name' => $name,
         'is_ranked' => false,
         'is_public' => true,

--- a/tests/Feature/Rankings/RankingCommentsTest.php
+++ b/tests/Feature/Rankings/RankingCommentsTest.php
@@ -11,7 +11,7 @@ describe('ranking comments', function () {
     test('displays comments component when comments are enabled', function () {
         $user = User::factory()->createOne();
 
-        $ranking = publicCompletedRanking([
+        $ranking = publicCompletedRanking(attributes: [
             'user_id' => $user->getKey(),
             'comments_enabled' => true,
         ]);
@@ -25,7 +25,7 @@ describe('ranking comments', function () {
     test('hides comments component when comments are disabled', function () {
         $user = User::factory()->createOne();
 
-        $ranking = publicCompletedRanking([
+        $ranking = publicCompletedRanking(attributes: [
             'user_id' => $user->getKey(),
             'comments_enabled' => false,
         ]);
@@ -59,7 +59,7 @@ describe('comment profanity filtering', function () {
 
 describe('ranking comment replies', function () {
     test('allows replies when comment replies are enabled', function () {
-        $ranking = publicCompletedRanking([
+        $ranking = publicCompletedRanking(attributes: [
             'comments_enabled' => true,
             'comments_replies_enabled' => true,
         ]);
@@ -70,7 +70,7 @@ describe('ranking comment replies', function () {
     });
 
     test('disables replies when comment replies are disabled', function () {
-        $ranking = publicCompletedRanking([
+        $ranking = publicCompletedRanking(attributes: [
             'comments_enabled' => true,
             'comments_replies_enabled' => false,
         ]);

--- a/tests/Feature/Rankings/RankingCreationTest.php
+++ b/tests/Feature/Rankings/RankingCreationTest.php
@@ -70,6 +70,10 @@ describe('creating rankings', function () {
 
         expect($ranking)->not->toBeNull();
         expect($ranking->songs()->count())->toBe(3);
+
+        expect($ranking->type)->toBe(RankingType::ARTIST);
+        expect($ranking->source)->toBeInstanceOf(Artist::class);
+        expect($ranking->source->is($artist))->toBeTrue();
     });
 
     test('can create a ranking for a playlist', function () {
@@ -140,6 +144,10 @@ describe('creating rankings', function () {
         $localNatives = Artist::where('artist_id', 'local-natives-id')->firstOrFail();
 
         expect($ranking->songs()->pluck('artist_id')->unique()->all())->toBe([$localNatives->getKey()]);
+
+        expect($ranking->type)->toBe(RankingType::PLAYLIST);
+        expect($ranking->source)->toBeInstanceOf(Playlist::class);
+        expect($ranking->source->is($playlist))->toBeTrue();
     });
 
     test('can create a ranking for a show', function () {
@@ -192,6 +200,23 @@ describe('creating rankings', function () {
 
         expect($ranking)->not->toBeNull();
         expect($ranking->songs()->count())->toBe(3);
+
+        expect($ranking->type)->toBe(RankingType::SHOW);
+        expect($ranking->source)->toBeInstanceOf(Show::class);
+        expect($ranking->source->is($show))->toBeTrue();
+    });
+
+    test('the type column stores the ranking type enum value', function () {
+        expect(Ranking::factory()->createOne()->getAttributes()['type'])->toBe('artist');
+        expect(Ranking::factory()->playlist()->createOne()->getAttributes()['type'])->toBe('playlist');
+        expect(Ranking::factory()->show()->createOne()->getAttributes()['type'])->toBe('show');
+    });
+
+    test('a ranking whose source no longer exists still resolves its type', function () {
+        $ranking = Ranking::factory()->createOne(['source_id' => null]);
+
+        expect($ranking->type)->toBe(RankingType::ARTIST);
+        expect($ranking->source)->toBeNull();
     });
 });
 

--- a/tests/Feature/Rankings/RankingExportTest.php
+++ b/tests/Feature/Rankings/RankingExportTest.php
@@ -15,7 +15,7 @@ describe('song export', function () {
     });
 
     test('uses the ranking name as the sheet title', function () {
-        $ranking = publicCompletedRanking(['name' => 'My Favourite Songs']);
+        $ranking = publicCompletedRanking(attributes: ['name' => 'My Favourite Songs']);
 
         expect(songExport($ranking)->title())->toBe('My Favourite Songs');
     });
@@ -71,8 +71,8 @@ describe('rankings export', function () {
     });
 
     test('renders a readable xlsx with a sheet per ranking', function () {
-        $first = publicCompletedRanking(['name' => 'First Ranking']);
-        $second = publicCompletedRanking(['name' => 'Second Ranking']);
+        $first = publicCompletedRanking(attributes: ['name' => 'First Ranking']);
+        $second = publicCompletedRanking(attributes: ['name' => 'Second Ranking']);
 
         $rankings = Ranking::query()
             ->with('songs.artist')

--- a/tests/Feature/Rankings/RankingShowPageTest.php
+++ b/tests/Feature/Rankings/RankingShowPageTest.php
@@ -50,7 +50,7 @@ describe('creator banner on the show page', function () {
         $owner = User::factory()->createOne(['name' => 'Ranking Creator']);
         $visitor = User::factory()->createOne();
 
-        $ranking = publicCompletedRanking(['user_id' => $owner->getKey()]);
+        $ranking = publicCompletedRanking(attributes: ['user_id' => $owner->getKey()]);
 
         actingAs($visitor)
             ->get(route('ranking', ['id' => $ranking->getKey()]))
@@ -62,7 +62,7 @@ describe('creator banner on the show page', function () {
     test('is shown to guests viewing the ranking', function () {
         $owner = User::factory()->createOne(['name' => 'Ranking Creator']);
 
-        $ranking = publicCompletedRanking(['user_id' => $owner->getKey()]);
+        $ranking = publicCompletedRanking(attributes: ['user_id' => $owner->getKey()]);
 
         get(route('ranking', ['id' => $ranking->getKey()]))
             ->assertOk()
@@ -73,7 +73,7 @@ describe('creator banner on the show page', function () {
     test('is hidden from the ranking creator', function () {
         $owner = User::factory()->createOne();
 
-        $ranking = publicCompletedRanking(['user_id' => $owner->getKey()]);
+        $ranking = publicCompletedRanking(attributes: ['user_id' => $owner->getKey()]);
 
         actingAs($owner)
             ->get(route('ranking', ['id' => $ranking->getKey()]))

--- a/tests/Filament/Resources/Playlists/PlaylistRankingsTest.php
+++ b/tests/Filament/Resources/Playlists/PlaylistRankingsTest.php
@@ -9,10 +9,7 @@ describe('playlist rankings', function () {
     test('lists the rankings built from the playlist', function () {
         $playlist = Playlist::factory()->createOne();
 
-        $ranking = publicCompletedRanking([
-            'artist_id' => null,
-            'playlist_id' => $playlist->getKey(),
-        ]);
+        $ranking = publicCompletedRanking($playlist);
 
         $otherRanking = publicCompletedRanking();
 

--- a/tests/Filament/Resources/Rankings/RankingInfolistTest.php
+++ b/tests/Filament/Resources/Rankings/RankingInfolistTest.php
@@ -1,9 +1,7 @@
 <?php
 
 use App\Filament\Resources\Rankings\Pages\ViewRanking;
-use App\Models\Playlist;
 use App\Models\Ranking;
-use App\Models\Show;
 use Livewire\Features\SupportTesting\Testable;
 use Livewire\Livewire;
 
@@ -18,10 +16,7 @@ describe('source sections', function () {
     });
 
     test('only shows playlist details for a playlist ranking', function () {
-        $ranking = Ranking::factory()->createOne([
-            'artist_id' => null,
-            'playlist_id' => Playlist::factory()->createOne()->getKey(),
-        ]);
+        $ranking = Ranking::factory()->playlist()->createOne();
 
         viewRanking($ranking)
             ->assertSee('Playlist Details')
@@ -30,19 +25,7 @@ describe('source sections', function () {
     });
 
     test('only shows show details for a show ranking', function () {
-        $show = Show::create([
-            'show_id' => str()->random(16),
-            'publisher' => 'Podcast Publisher',
-            'name' => 'True Crime Weekly',
-            'description' => 'A weekly true crime show.',
-            'cover' => 'https://example.com/cover.jpg',
-            'episode_count' => 100,
-        ]);
-
-        $ranking = Ranking::factory()->createOne([
-            'artist_id' => null,
-            'show_id' => $show->getKey(),
-        ]);
+        $ranking = Ranking::factory()->show()->createOne();
 
         viewRanking($ranking)
             ->assertSee('Show Details')

--- a/tests/Filament/Resources/Rankings/RankingSourceColumnTest.php
+++ b/tests/Filament/Resources/Rankings/RankingSourceColumnTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Filament\Resources\Rankings\Pages\ListRankings;
+use App\Models\Artist;
+use App\Models\Playlist;
+use App\Models\Show;
+use Livewire\Livewire;
+
+describe('source column', function () {
+    test('renders the source name for every ranking type', function () {
+        $artistRanking = publicCompletedRanking(Artist::factory()->createOne(['artist_name' => 'Column Artist']));
+        $playlistRanking = publicCompletedRanking(Playlist::factory()->createOne(['name' => 'Column Playlist']));
+        $showRanking = publicCompletedRanking(Show::factory()->createOne(['name' => 'Column Show']));
+
+        Livewire::actingAs(kyle())
+            ->test(ListRankings::class)
+            ->assertCanSeeTableRecords([$artistRanking, $playlistRanking, $showRanking])
+            ->assertSee('Column Artist')
+            ->assertSee('Column Playlist')
+            ->assertSee('Column Show');
+    });
+
+    test('searching by artist name finds only the artist ranking', function () {
+        assertSourceSearchFinds('Needle Artist', Artist::factory()->createOne(['artist_name' => 'Needle Artist']));
+    });
+
+    test('searching by playlist name finds only the playlist ranking', function () {
+        assertSourceSearchFinds('Needle Playlist', Playlist::factory()->createOne(['name' => 'Needle Playlist']));
+    });
+
+    test('searching by show name finds only the show ranking', function () {
+        assertSourceSearchFinds('Needle Show', Show::factory()->createOne(['name' => 'Needle Show']));
+    });
+});
+
+function assertSourceSearchFinds(string $search, $source): void
+{
+    $match = publicCompletedRanking($source);
+    $other = publicCompletedRanking(Artist::factory()->createOne(['artist_name' => 'Unrelated Artist']));
+
+    Livewire::actingAs(kyle())
+        ->test(ListRankings::class)
+        ->searchTable($search)
+        ->assertCanSeeTableRecords([$match])
+        ->assertCanNotSeeTableRecords([$other]);
+}

--- a/tests/Filament/Resources/SpotifyLinksTest.php
+++ b/tests/Filament/Resources/SpotifyLinksTest.php
@@ -19,14 +19,7 @@ describe('spotify links', function () {
     });
 
     test('links a show back to spotify', function () {
-        $show = Show::create([
-            'show_id' => str()->random(16),
-            'publisher' => 'Podcast Publisher',
-            'name' => 'True Crime Weekly',
-            'description' => 'A weekly true crime show.',
-            'cover' => 'https://example.com/cover.jpg',
-            'episode_count' => 100,
-        ]);
+        $show = Show::factory()->createOne();
 
         Livewire::actingAs(kyle())
             ->test(ViewShow::class, ['record' => $show->getKey()])

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Contracts\Rankable;
 use App\Models\Ranking;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -34,9 +35,19 @@ pest()->extend(TestCase::class)
 |
 */
 
-function publicCompletedRanking(array $attributes = []): Ranking
+/**
+ * Pass a $source (Artist, Playlist or Show) to control what the ranking is of;
+ * it defaults to a fresh artist via the factory.
+ */
+function publicCompletedRanking(?Rankable $source = null, array $attributes = []): Ranking
 {
-    return Ranking::factory()->create(array_merge([
+    $factory = Ranking::factory();
+
+    if ($source) {
+        $factory = $factory->for($source, 'source');
+    }
+
+    return $factory->create(array_merge([
         'is_public' => true,
         'is_ranked' => true,
         'completed_at' => now(),


### PR DESCRIPTION
Refactors the `Ranking` model to use a polymorphic `source` relationship, replacing the individual `artist_id`, `playlist_id`, and `show_id` columns with `source_id` and a `type` field.

This change:
- Simplifies the `Ranking` table schema and model definition.
- Enhances extensibility, allowing for easier addition of new rankable entities.
- Streamlines data fetching and display logic across the application, including Livewire components, Filament admin panels, and database queries.

Includes a data migration to safely transition existing rankings to the new schema.